### PR TITLE
v0.7.0 — MCPB packaging + GitHub-refreshed index tier

### DIFF
--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -1,0 +1,92 @@
+name: Publish MCPB bundle
+
+# Packs the repo into a Claude Desktop extension (.mcpb) and attaches it
+# to the GitHub Release for the tag. Bundle uses server type `uv`, so the
+# source tree ships as-is and `uv` resolves dependencies from
+# pyproject.toml at install time on the user's machine — no vendored
+# wheels, no platform-specific builds.
+#
+# Trigger: every `v*` tag push (same trigger as publish-pypi.yml), plus
+# manual via workflow_dispatch for re-packing without a new tag.
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  # Needed to create/update the GitHub Release and upload the .mcpb asset.
+  contents: write
+
+jobs:
+  pack-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Verify manifest version matches tag and pyproject
+        # Three-way check: git tag ↔ pyproject version ↔ manifest version.
+        # Catches the "bumped one, forgot the other" mistake — MCPB users
+        # would otherwise get a bundle labelled with a different version
+        # than the PyPI release it corresponds to.
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MANIFEST_VERSION=$(python3 -c "import json; print(json.load(open('manifest.json'))['version'])")
+          echo "Tag:      $TAG_VERSION"
+          echo "Package:  $PKG_VERSION"
+          echo "Manifest: $MANIFEST_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ] || [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "::error::Version mismatch between git tag, pyproject.toml, and manifest.json"
+            exit 1
+          fi
+
+      - name: Install mcpb CLI
+        run: npm install -g @anthropic-ai/mcpb
+
+      - name: Validate manifest
+        run: mcpb validate manifest.json
+
+      - name: Pack bundle
+        id: pack
+        run: |
+          # Explicit output name so the asset is predictable across
+          # runs — `mcpb pack .` otherwise defaults to dirname.mcpb,
+          # which on CI is the checkout directory name.
+          VERSION=$(python3 -c "import json; print(json.load(open('manifest.json'))['version'])")
+          BUNDLE="vipmp-docs-mcp-${VERSION}.mcpb"
+          mcpb pack . "$BUNDLE"
+          if [ ! -f "$BUNDLE" ]; then
+            echo "::error::mcpb pack did not produce $BUNDLE"
+            exit 1
+          fi
+          echo "bundle=$BUNDLE" >> "$GITHUB_OUTPUT"
+          echo "Built: $BUNDLE ($(stat -c%s "$BUNDLE") bytes)"
+
+      - name: Upload bundle as workflow artifact
+        # Always available via the run page, regardless of release step.
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcpb-bundle
+          path: ${{ steps.pack.outputs.bundle }}
+          if-no-files-found: error
+
+      - name: Attach bundle to GitHub Release
+        # Creates the Release if the tag doesn't have one yet, otherwise
+        # updates it. Skipped for workflow_dispatch runs (no tag context).
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.pack.outputs.bundle }}
+          fail_on_unmatched_files: true

--- a/.mcpbignore
+++ b/.mcpbignore
@@ -1,0 +1,53 @@
+# Files excluded from the packed .mcpb bundle.
+# Only ship what `uv run` needs at runtime (pyproject.toml + src/) plus
+# the bits required by the MCPB spec (manifest.json) and the usual
+# legal/README boilerplate.
+
+# VCS
+.git/
+.gitignore
+.gitattributes
+.github/
+
+# Claude Code worktrees / local settings
+.claude/
+
+# Dev-only directories
+tests/
+scripts/
+examples/
+
+# Dev-only docs (keep README.md + LICENSE + NOTICE)
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+
+# Python build / cache artefacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info/
+*.egg
+build/
+dist/
+.venv/
+venv/
+env/
+
+# Test / lint caches
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+coverage.xml
+htmlcov/
+
+# Editor / OS cruft
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# Local env overrides
+.env
+.env.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-04-19
+
+### Added
+- **Claude Desktop extension packaging.** The repo now ships as a
+  `.mcpb` bundle via a new `.github/workflows/publish-mcpb.yml` workflow
+  that runs on every `v*` tag push. Uses `server.type: "uv"` so the
+  bundle itself is tiny (~85 kB) — dependencies resolve from
+  `pyproject.toml` via `uv` on the user's machine. Manifest enumerates
+  all 17 tools for the extension UI. Sideloaded `.mcpb` files do not
+  auto-update (that's Anthropic-directory-only), so the workflow
+  enforces tag ↔ pyproject ↔ manifest version parity to keep the
+  artefact and the PyPI release aligned.
+- **GitHub-refreshed remote-index tier.** New
+  `src/vipmp_docs_mcp/remote_index.py` fetches the current
+  `data/index.json` from `main` on raw.githubusercontent.com and uses
+  it when it's fresher than the baseline shipped in the installed
+  wheel. 12-hour TTL, ETag revalidation (304 costs no bandwidth),
+  atomic writes. `resolve_active_index()` in `index.py` now walks four
+  tiers: user-local rebuild → github-remote → package baseline →
+  live-extraction fallback. Merging the daily `refresh-index` PR is now
+  enough to put fresh data on users' machines within 12 h — no PyPI
+  release or `uvx` cache dance required.
+- **`VIPMP_DISABLE_REMOTE_INDEX`** environment variable for
+  deterministic runs (tests, air-gapped environments, forensic
+  debugging). When set to a truthy value, the remote tier is skipped
+  and the package baseline is used directly.
+- **`vipmp_server_info` now reports the active index tier** and the
+  remote-index cache state (fetched-at, TTL, URL, opt-out status) so
+  users can see which source their tool results are coming from.
+
+### Internal
+- `index.py` gains `ActiveIndex` (snapshot + source label + path) and
+  `resolve_active_index()`. `get_active_index()` is retained as a
+  backwards-compatible wrapper — all seven existing callers in
+  `server.py` keep working without changes.
+- Remote-index tier is always stale-OK: any transport error, non-JSON
+  response, or unexpected exception falls back to whatever is on disk
+  and, failing that, to the package baseline. Never raises.
+- Added 21 new tests (17 in `tests/test_remote_index.py` covering
+  opt-out, fresh fetch, 304 revalidation, TTL short-circuit, network
+  failure fallback, and status reporting; 4 in `tests/test_index.py`
+  covering tier priority).
+
 ## [0.6.1] — 2026-04-18
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,55 @@
+{
+  "manifest_version": "0.4",
+  "name": "vipmp-docs-mcp",
+  "display_name": "Adobe VIP Marketplace Docs",
+  "version": "0.7.0",
+  "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
+  "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes — without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
+  "author": {
+    "name": "SoftwareOne AG",
+    "url": "https://github.com/softwareone-platform"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp"
+  },
+  "homepage": "https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp",
+  "documentation": "https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp#readme",
+  "support": "https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/issues",
+  "license": "Apache-2.0",
+  "keywords": ["adobe", "vipmp", "vip-marketplace", "documentation", "api", "mcp"],
+  "server": {
+    "type": "uv",
+    "entry_point": "src/vipmp_docs_mcp/server.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": ["run", "--directory", "${__dirname}", "vipmp-docs-mcp"]
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "linux", "win32"],
+    "runtimes": {
+      "python": ">=3.12"
+    }
+  },
+  "prompts_generated": true,
+  "tools": [
+    { "name": "list_vipmp_docs", "description": "Return the full sitemap of Adobe VIP Marketplace API documentation." },
+    { "name": "search_vipmp_docs", "description": "Search the docs by keyword or topic, ranked by title/tag/content matches." },
+    { "name": "get_vipmp_page", "description": "Fetch the full cleaned content of a specific documentation page." },
+    { "name": "warm_vipmp_cache", "description": "Pre-fetch every documentation page for stronger content-aware search." },
+    { "name": "refresh_vipmp_sitemap", "description": "Rebuild the documentation sitemap from Adobe's live sitemap.xml." },
+    { "name": "vipmp_cache_stats", "description": "Report cache size, freshness, TTL, and on-disk path." },
+    { "name": "vipmp_cache_clear", "description": "Drop one cache entry or wipe the whole cache." },
+    { "name": "list_vipmp_endpoints", "description": "List every REST endpoint (method, path, source page) from the index." },
+    { "name": "list_vipmp_error_codes", "description": "List all numeric and symbolic error codes with triggers." },
+    { "name": "get_vipmp_schema", "description": "Return the field schema for a resource (name, type, required, constraints)." },
+    { "name": "get_vipmp_code_examples", "description": "Pull code blocks off a documentation page, optionally filtered by language." },
+    { "name": "rebuild_vipmp_index", "description": "Rebuild the structured endpoints/error-codes/schemas index from live docs." },
+    { "name": "list_vipmp_releases", "description": "Structured release notes — dated entries grouped by section." },
+    { "name": "vipmp_server_info", "description": "Diagnostic info: version, Python, index age, cache stats, log path." },
+    { "name": "describe_vipmp_endpoint", "description": "One-shot endpoint profile: schema, error codes, release notes, examples." },
+    { "name": "validate_vipmp_request", "description": "Check a JSON request body against the endpoint's published schema." },
+    { "name": "generate_vipmp_request", "description": "Emit a runnable curl / PowerShell / Python / C# snippet for an endpoint." }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.6.1"
+version = "0.7.0"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/vipmp_docs_mcp/__init__.py
+++ b/src/vipmp_docs_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Adobe VIP Marketplace Docs MCP Server."""
 
-__version__ = "0.6.1"
+__version__ = "0.7.0"

--- a/src/vipmp_docs_mcp/index.py
+++ b/src/vipmp_docs_mcp/index.py
@@ -5,11 +5,13 @@ Lets `list_vipmp_endpoints`, `list_vipmp_error_codes`, `get_vipmp_schema`,
 and `get_vipmp_releases` answer in milliseconds instead of re-extracting
 from HTML on every call.
 
-Three-tier resolution for the active index:
+Resolution chain for the active index:
     1. User-local rebuild (~/.cache/.../index.json) — freshest, if present
-    2. Package-shipped baseline (src/vipmp_docs_mcp/data/index.json) —
-       refreshed weekly by GitHub Actions and published with releases
-    3. None — tools fall back to on-the-fly extraction
+    2. GitHub-refreshed remote (~/.cache/.../remote-index.json) — pulled
+       on demand from `main`, TTL 12h. See remote_index.py.
+    3. Package-shipped baseline (src/vipmp_docs_mcp/data/index.json) —
+       refreshed daily by GitHub Actions and published with releases.
+    4. None — tools fall back to on-the-fly extraction.
 """
 
 from __future__ import annotations
@@ -225,18 +227,57 @@ def load_index(path: Path) -> IndexSnapshot | None:
     return IndexSnapshot.from_dict(data)
 
 
-def get_active_index() -> IndexSnapshot | None:
+@dataclass
+class ActiveIndex:
+    """The loaded index plus metadata about which tier it came from."""
+
+    snapshot: IndexSnapshot
+    source: str  # "user-local" | "github-remote" | "package-baseline"
+    path: Path
+
+
+def resolve_active_index() -> ActiveIndex | None:
     """
-    Return the freshest index available: user-local rebuild first, then
-    the package-shipped baseline, then None.
+    Walk the tier chain and return the first usable index along with its
+    source label. See the module docstring for the tier order.
+
+    The github-remote tier may trigger a network fetch (conditional GET,
+    subject to a 12h TTL). It degrades silently on any failure — the
+    caller always ends up with the package baseline if no fresher source
+    works.
     """
     user = load_index(USER_INDEX_PATH)
     if user is not None:
         log.debug("using user-local index (age=%.0fs)", user.age_seconds)
-        return user
+        return ActiveIndex(user, "user-local", USER_INDEX_PATH)
+
+    # Local import to avoid a circular dependency at module load time —
+    # remote_index doesn't import index, but this keeps the coupling
+    # one-way at runtime as well.
+    from .remote_index import ensure_fresh
+
+    remote_path = ensure_fresh()
+    if remote_path is not None:
+        remote = load_index(remote_path)
+        if remote is not None:
+            log.debug("using github-remote index (age=%.0fs)", remote.age_seconds)
+            return ActiveIndex(remote, "github-remote", remote_path)
+
     pkg = load_index(PACKAGE_INDEX_PATH)
     if pkg is not None:
         log.debug("using package-shipped index (age=%.0fs)", pkg.age_seconds)
-        return pkg
+        return ActiveIndex(pkg, "package-baseline", PACKAGE_INDEX_PATH)
+
     log.debug("no index available; callers will fall back to live extraction")
     return None
+
+
+def get_active_index() -> IndexSnapshot | None:
+    """
+    Return the freshest index snapshot available, or None if no tier
+    yielded a usable index. Thin wrapper over ``resolve_active_index``
+    kept for backwards compatibility with callers that don't need the
+    source label.
+    """
+    active = resolve_active_index()
+    return active.snapshot if active is not None else None

--- a/src/vipmp_docs_mcp/remote_index.py
+++ b/src/vipmp_docs_mcp/remote_index.py
@@ -1,0 +1,217 @@
+"""
+GitHub-refreshed index tier — keeps `data/index.json` fresh between PyPI releases.
+
+The package ships with a baseline ``data/index.json``, but that file ages as
+soon as the wheel is built. A daily GitHub Actions workflow rebuilds the index
+on ``main``, yet users don't see that refresh until a new PyPI version is
+tagged and their ``uvx`` cache turns over. This module closes that gap.
+
+On demand (first index-requiring tool call per session, subject to the TTL):
+
+  1. If a cached copy is within the TTL window, use it — no network.
+  2. Otherwise do a conditional GET against raw.githubusercontent.com with
+     the stored ETag. 304 is free; 200 overwrites the cache atomically.
+  3. If the fetch fails for any reason (offline, rate limit, DNS, timeout,
+     non-JSON response, GitHub 5xx) we fall back to whatever is on disk,
+     logging a warning. This tier is always stale-OK: it only ever *adds*
+     freshness, it never blocks the server.
+
+Opt-out: set ``VIPMP_DISABLE_REMOTE_INDEX=1`` for deterministic runs (tests,
+air-gapped environments, forensic debugging). Users on the opt-out path get
+the package baseline as before.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import httpx
+from tenacity import (
+    RetryError,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from .logging_config import CACHE_DIR, get_logger
+
+log = get_logger("remote_index")
+
+REMOTE_INDEX_URL = (
+    "https://raw.githubusercontent.com/softwareone-platform/"
+    "swo-adobe-vipm-docs-mcp/main/src/vipmp_docs_mcp/data/index.json"
+)
+
+REMOTE_INDEX_PATH = CACHE_DIR / "remote-index.json"
+REMOTE_INDEX_META_PATH = CACHE_DIR / "remote-index.meta.json"
+
+TTL_SECONDS = 12 * 3600
+
+DISABLE_ENV = "VIPMP_DISABLE_REMOTE_INDEX"
+
+_FETCH_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
+
+
+def _is_disabled() -> bool:
+    return os.environ.get(DISABLE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _load_meta(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        log.debug("meta file unreadable at %s; treating as empty", path)
+        return {}
+
+
+def _save_meta(meta: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(meta, f)
+    os.replace(tmp, path)
+
+
+def _within_ttl(meta: dict) -> bool:
+    try:
+        fetched_at = float(meta.get("fetched_at", 0.0))
+    except (TypeError, ValueError):
+        return False
+    return (time.time() - fetched_at) < TTL_SECONDS
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5, min=0.5, max=4.0),
+    retry=retry_if_exception(
+        lambda e: isinstance(e, (httpx.TransportError, httpx.TimeoutException))
+    ),
+    reraise=True,
+)
+def _conditional_get(etag: str | None) -> httpx.Response:
+    """Conditional GET against REMOTE_INDEX_URL. Transient transport/timeout errors retry."""
+    headers: dict[str, str] = {
+        "User-Agent": "SWOVIPMPDocsMCP-remote-index (+https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp)",
+        "Accept": "application/json",
+    }
+    if etag:
+        headers["If-None-Match"] = etag
+    with httpx.Client(timeout=_FETCH_TIMEOUT, follow_redirects=True) as client:
+        return client.get(REMOTE_INDEX_URL, headers=headers)
+
+
+def _write_atomic(body: bytes, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "wb") as f:
+        f.write(body)
+    os.replace(tmp, path)
+
+
+def ensure_fresh() -> Path | None:
+    """
+    Return the on-disk path to a usable remote index, refreshing it if the
+    TTL has expired. Returns None only if the tier is disabled and there is
+    nothing cached (the caller should then fall through to the package
+    baseline).
+
+    Never raises. Every failure mode degrades to "use what's on disk, if
+    anything." The baseline tier in index.py is the true safety net.
+    """
+    if _is_disabled():
+        log.debug("remote index disabled via %s", DISABLE_ENV)
+        return None
+
+    # Look these up per-call so tests (and any future caller) can
+    # monkeypatch the module-level constants — function-default-arg
+    # bindings would be captured at def-time and miss the patch.
+    index_path = REMOTE_INDEX_PATH
+    meta_path = REMOTE_INDEX_META_PATH
+
+    have_cached = index_path.exists()
+    meta = _load_meta(meta_path)
+
+    # Short-circuit: inside the TTL window we trust what's on disk and
+    # don't make a network call. This is the common case — typical
+    # sessions hit disk for free and never touch GitHub.
+    if have_cached and _within_ttl(meta):
+        log.debug("remote index within TTL (fetched %.1fh ago); using cache",
+                  (time.time() - float(meta.get("fetched_at", 0))) / 3600)
+        return index_path
+
+    etag = meta.get("etag") if have_cached else None
+
+    try:
+        response = _conditional_get(etag)
+    except (httpx.TransportError, httpx.TimeoutException, RetryError) as exc:
+        log.warning("remote index unreachable (%s); using cached copy if any", exc)
+        return index_path if have_cached else None
+    except Exception as exc:  # defensive: never propagate from this tier
+        log.warning("remote index fetch raised unexpected %s: %s", type(exc).__name__, exc)
+        return index_path if have_cached else None
+
+    if response.status_code == 304:
+        log.debug("remote index 304 Not Modified — bumping fetched_at")
+        meta["fetched_at"] = time.time()
+        _save_meta(meta, meta_path)
+        return index_path
+
+    if response.status_code != 200:
+        log.warning(
+            "remote index fetch got HTTP %s; using cached copy if any",
+            response.status_code,
+        )
+        return index_path if have_cached else None
+
+    body = response.content
+    try:
+        # Sanity-parse: don't write garbage to disk. Schema validation
+        # happens when index.py tries to load the file — rejecting it
+        # there falls through to the baseline tier, which is correct.
+        json.loads(body)
+    except json.JSONDecodeError as exc:
+        log.warning("remote index response is not valid JSON (%s); ignoring", exc)
+        return index_path if have_cached else None
+
+    _write_atomic(body, index_path)
+    _save_meta(
+        {
+            "fetched_at": time.time(),
+            "etag": response.headers.get("ETag"),
+            "content_length": len(body),
+            "source_url": REMOTE_INDEX_URL,
+        },
+        meta_path,
+    )
+    log.info(
+        "refreshed remote index from GitHub (%d bytes, etag=%s)",
+        len(body),
+        response.headers.get("ETag"),
+    )
+    return index_path
+
+
+def get_status() -> dict:
+    """
+    Describe the remote-index tier state without triggering a fetch.
+    Used by ``vipmp_server_info`` to show what users actually have.
+    """
+    if _is_disabled():
+        return {"enabled": False, "reason": f"{DISABLE_ENV} is set"}
+    meta = _load_meta(REMOTE_INDEX_META_PATH)
+    return {
+        "enabled": True,
+        "cached": REMOTE_INDEX_PATH.exists(),
+        "fetched_at": meta.get("fetched_at"),
+        "etag": meta.get("etag"),
+        "ttl_seconds": TTL_SECONDS,
+        "url": REMOTE_INDEX_URL,
+        "path": str(REMOTE_INDEX_PATH),
+    }

--- a/src/vipmp_docs_mcp/server.py
+++ b/src/vipmp_docs_mcp/server.py
@@ -27,6 +27,7 @@ from .index import (
     USER_INDEX_PATH,
     build_index,
     get_active_index,
+    resolve_active_index,
     save_index,
 )
 from .logging_config import configure_logging, get_logger
@@ -894,28 +895,54 @@ def vipmp_server_info() -> str:
     """
     import platform
     import sys
+    import time
     from pathlib import Path
 
     from . import __version__
     from .autositemap import SITEMAP_JSON_PATH
     from .logging_config import LOG_FILE
+    from .remote_index import get_status as remote_index_status
 
-    idx = get_active_index()
+    active = resolve_active_index()
     cache = get_cache()
     cache_stats = cache.stats()
     sitemap = _get_sitemap()
 
-    idx_line = (
-        f"{idx.pages_parsed} pages, "
-        f"{len(idx.endpoints)} endpoints "
-        f"({sum(1 for e in idx.endpoints if e.deprecated)} deprecated), "
-        f"{len(idx.error_codes)} error codes, "
-        f"{len(idx.schemas)} schemas, "
-        f"{len(idx.releases)} releases — "
-        f"built {idx.age_seconds / 3600:.1f}h ago"
-        if idx
-        else "_(no index available — call `rebuild_vipmp_index`)_"
-    )
+    if active is not None:
+        idx = active.snapshot
+        idx_line = (
+            f"{idx.pages_parsed} pages, "
+            f"{len(idx.endpoints)} endpoints "
+            f"({sum(1 for e in idx.endpoints if e.deprecated)} deprecated), "
+            f"{len(idx.error_codes)} error codes, "
+            f"{len(idx.schemas)} schemas, "
+            f"{len(idx.releases)} releases — "
+            f"built {idx.age_seconds / 3600:.1f}h ago"
+        )
+        idx_source_line = f"- **Source:** `{active.source}` (`{active.path}`)"
+    else:
+        idx_line = "_(no index available — call `rebuild_vipmp_index`)_"
+        idx_source_line = "- **Source:** _(none — live extraction only)_"
+
+    # Remote-index tier — opt-in freshness booster. Report its state even
+    # if the active source ended up being user-local (still useful for
+    # "is the remote refresh actually happening?" debugging).
+    remote = remote_index_status()
+    if not remote.get("enabled", False):
+        remote_line = f"- **Status:** disabled — {remote.get('reason', 'unknown')}"
+    elif remote.get("cached"):
+        fetched_at = remote.get("fetched_at")
+        age_hours = (time.time() - float(fetched_at)) / 3600 if fetched_at else None
+        age_str = f"{age_hours:.1f}h ago" if age_hours is not None else "unknown"
+        remote_line = (
+            f"- **Status:** cached, last fetched {age_str} "
+            f"(TTL {remote['ttl_seconds'] // 3600}h)"
+        )
+    else:
+        remote_line = (
+            f"- **Status:** enabled, nothing cached yet "
+            f"(TTL {remote['ttl_seconds'] // 3600}h)"
+        )
 
     sitemap_json_exists = Path(SITEMAP_JSON_PATH).exists()
 
@@ -929,6 +956,11 @@ def vipmp_server_info() -> str:
         "",
         "## Index",
         f"- {idx_line}",
+        idx_source_line,
+        "",
+        "## Remote index (GitHub refresh tier)",
+        remote_line,
+        f"- **URL:** `{remote.get('url', 'n/a')}`",
         "",
         "## Sitemap",
         f"- **Entries in active sitemap:** {len(sitemap)}",

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -6,11 +6,16 @@ import json
 import time
 from pathlib import Path
 
+import pytest
+
+from vipmp_docs_mcp import index as index_module
+from vipmp_docs_mcp import remote_index
 from vipmp_docs_mcp.extractors import Endpoint, ErrorCode, SchemaField, SchemaResource
 from vipmp_docs_mcp.index import (
     INDEX_SCHEMA_VERSION,
     IndexSnapshot,
     load_index,
+    resolve_active_index,
     save_index,
 )
 
@@ -91,6 +96,64 @@ class TestLoadIndex:
         path = tmp_path / "bad.json"
         path.write_text("not json {{{")
         assert load_index(path) is None
+
+
+class TestResolveActiveIndex:
+    """
+    Integration-level tests for the tier chain. Each test redirects every
+    tier's path to a tmp location and asserts which one wins.
+    """
+
+    @pytest.fixture(autouse=True)
+    def isolate_paths(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        self.user_path = tmp_path / "user-index.json"
+        self.remote_path = tmp_path / "remote-index.json"
+        self.remote_meta = tmp_path / "remote-index.meta.json"
+        self.pkg_path = tmp_path / "pkg-index.json"
+        monkeypatch.setattr(index_module, "USER_INDEX_PATH", self.user_path)
+        monkeypatch.setattr(index_module, "PACKAGE_INDEX_PATH", self.pkg_path)
+        monkeypatch.setattr(remote_index, "REMOTE_INDEX_PATH", self.remote_path)
+        monkeypatch.setattr(remote_index, "REMOTE_INDEX_META_PATH", self.remote_meta)
+        # Disable network — tier resolution should never hit the wire here.
+        monkeypatch.setenv(remote_index.DISABLE_ENV, "1")
+
+    def _write(self, path: Path, snap: IndexSnapshot) -> None:
+        save_index(snap, path)
+
+    def test_user_local_wins_over_remote_and_baseline(self):
+        self._write(self.user_path, _sample_snap())
+        self._write(self.remote_path, _sample_snap())
+        self._write(self.pkg_path, _sample_snap())
+
+        active = resolve_active_index()
+        assert active is not None
+        assert active.source == "user-local"
+        assert active.path == self.user_path
+
+    def test_baseline_used_when_user_and_remote_absent(self):
+        self._write(self.pkg_path, _sample_snap())
+
+        active = resolve_active_index()
+        assert active is not None
+        assert active.source == "package-baseline"
+        assert active.path == self.pkg_path
+
+    def test_remote_wins_over_baseline(self, monkeypatch: pytest.MonkeyPatch):
+        # Re-enable the remote tier and pre-populate its cache file so
+        # ensure_fresh() short-circuits on TTL.
+        monkeypatch.delenv(remote_index.DISABLE_ENV, raising=False)
+        self._write(self.remote_path, _sample_snap())
+        self.remote_meta.write_text(json.dumps({"fetched_at": time.time(), "etag": "x"}))
+        self._write(self.pkg_path, _sample_snap())
+
+        active = resolve_active_index()
+        assert active is not None
+        assert active.source == "github-remote"
+        assert active.path == self.remote_path
+
+    def test_none_when_nothing_available(self):
+        active = resolve_active_index()
+        assert active is None
 
 
 class TestAgeSeconds:

--- a/tests/test_remote_index.py
+++ b/tests/test_remote_index.py
@@ -1,0 +1,185 @@
+"""
+Tests for the GitHub-refreshed index tier.
+
+Every test monkeypatches REMOTE_INDEX_PATH / REMOTE_INDEX_META_PATH onto a
+fresh tmp_path so nothing escapes into the real user cache. The module-
+level constants stay the product-facing defaults; tests treat them as
+injection points.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
+
+from vipmp_docs_mcp import remote_index
+
+
+@pytest.fixture(autouse=True)
+def isolate_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Redirect all remote-index disk paths into tmp_path for every test."""
+    idx = tmp_path / "remote-index.json"
+    meta = tmp_path / "remote-index.meta.json"
+    monkeypatch.setattr(remote_index, "REMOTE_INDEX_PATH", idx)
+    monkeypatch.setattr(remote_index, "REMOTE_INDEX_META_PATH", meta)
+    # Clear the env var so tests don't accidentally inherit a disable flag.
+    monkeypatch.delenv(remote_index.DISABLE_ENV, raising=False)
+    return idx, meta
+
+
+SAMPLE_BODY = json.dumps({"schema_version": 4, "endpoints": []}).encode()
+
+
+class TestDisabled:
+    def test_env_var_disables(
+        self, monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+    ):
+        monkeypatch.setenv(remote_index.DISABLE_ENV, "1")
+        # If the tier runs, pytest-httpx will complain about the unmocked request.
+        assert remote_index.ensure_fresh() is None
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "ON", " 1 "])
+    def test_env_var_truthy_values(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ):
+        monkeypatch.setenv(remote_index.DISABLE_ENV, value)
+        assert remote_index.ensure_fresh() is None
+
+    def test_env_var_empty_does_not_disable(
+        self, monkeypatch: pytest.MonkeyPatch, httpx_mock: HTTPXMock
+    ):
+        monkeypatch.setenv(remote_index.DISABLE_ENV, "")
+        httpx_mock.add_response(url=remote_index.REMOTE_INDEX_URL, content=SAMPLE_BODY)
+        assert remote_index.ensure_fresh() == remote_index.REMOTE_INDEX_PATH
+
+
+class TestFreshFetch:
+    def test_first_fetch_writes_body_and_meta(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, meta = isolate_cache
+        httpx_mock.add_response(
+            url=remote_index.REMOTE_INDEX_URL,
+            content=SAMPLE_BODY,
+            headers={"ETag": 'W/"abc123"'},
+        )
+
+        path = remote_index.ensure_fresh()
+        assert path == idx
+        assert idx.read_bytes() == SAMPLE_BODY
+
+        meta_data = json.loads(meta.read_text())
+        assert meta_data["etag"] == 'W/"abc123"'
+        assert meta_data["content_length"] == len(SAMPLE_BODY)
+        assert abs(meta_data["fetched_at"] - time.time()) < 5
+
+    def test_non_json_response_discarded(self, httpx_mock: HTTPXMock, isolate_cache):
+        idx, _ = isolate_cache
+        httpx_mock.add_response(
+            url=remote_index.REMOTE_INDEX_URL,
+            content=b"<html>rate limited</html>",
+        )
+        # No cached copy, so we return None rather than writing garbage.
+        assert remote_index.ensure_fresh() is None
+        assert not idx.exists()
+
+    def test_non_200_response_returns_none_when_uncached(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, _ = isolate_cache
+        httpx_mock.add_response(url=remote_index.REMOTE_INDEX_URL, status_code=500)
+        assert remote_index.ensure_fresh() is None
+        assert not idx.exists()
+
+
+class TestTTLShortCircuit:
+    def test_within_ttl_skips_network(self, isolate_cache):
+        idx, meta = isolate_cache
+        idx.write_bytes(SAMPLE_BODY)
+        meta.write_text(json.dumps({"fetched_at": time.time() - 60, "etag": "x"}))
+
+        # No httpx_mock responses registered — any network call would fail.
+        assert remote_index.ensure_fresh() == idx
+
+    def test_expired_ttl_triggers_conditional_get(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, meta = isolate_cache
+        idx.write_bytes(SAMPLE_BODY)
+        stale = time.time() - (remote_index.TTL_SECONDS + 100)
+        meta.write_text(json.dumps({"fetched_at": stale, "etag": 'W/"old"'}))
+
+        # Assert the request carries the stored ETag.
+        httpx_mock.add_response(
+            url=remote_index.REMOTE_INDEX_URL,
+            match_headers={"If-None-Match": 'W/"old"'},
+            status_code=304,
+        )
+
+        assert remote_index.ensure_fresh() == idx
+
+        # 304 updates fetched_at but preserves the ETag and body.
+        meta_data = json.loads(meta.read_text())
+        assert meta_data["etag"] == 'W/"old"'
+        assert abs(meta_data["fetched_at"] - time.time()) < 5
+
+
+class TestNetworkFailureFallback:
+    def test_transport_error_returns_cached_copy(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, meta = isolate_cache
+        idx.write_bytes(SAMPLE_BODY)
+        meta.write_text(
+            json.dumps({"fetched_at": time.time() - remote_index.TTL_SECONDS - 1})
+        )
+
+        # Simulate GitHub unreachable for every retry attempt.
+        for _ in range(3):
+            httpx_mock.add_exception(httpx.ConnectError("boom"))
+
+        path = remote_index.ensure_fresh()
+        assert path == idx  # stale-OK: we keep what we had
+        assert idx.read_bytes() == SAMPLE_BODY
+
+    def test_transport_error_returns_none_when_uncached(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, _ = isolate_cache
+        for _ in range(3):
+            httpx_mock.add_exception(httpx.ConnectError("boom"))
+        assert remote_index.ensure_fresh() is None
+        assert not idx.exists()
+
+
+class TestStatus:
+    def test_reports_disabled(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv(remote_index.DISABLE_ENV, "1")
+        status = remote_index.get_status()
+        assert status == {"enabled": False, "reason": f"{remote_index.DISABLE_ENV} is set"}
+
+    def test_reports_cached_state(self, isolate_cache):
+        idx, meta = isolate_cache
+        idx.write_bytes(SAMPLE_BODY)
+        meta.write_text(json.dumps({"fetched_at": 1234567890.0, "etag": "x"}))
+
+        status = remote_index.get_status()
+        assert status["enabled"] is True
+        assert status["cached"] is True
+        assert status["fetched_at"] == 1234567890.0
+        assert status["etag"] == "x"
+        assert status["ttl_seconds"] == remote_index.TTL_SECONDS
+
+    def test_status_does_not_trigger_fetch(self, isolate_cache):
+        idx, meta = isolate_cache
+        # No httpx_mock fixture here — if get_status hit the network the
+        # test would fail with an unmocked-request error.
+        status = remote_index.get_status()
+        assert status["cached"] is False
+        assert not idx.exists()
+        assert not meta.exists()


### PR DESCRIPTION
## Summary

Catches `main` up to the already-published [v0.7.0 release](https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/releases/tag/v0.7.0). Two features landed together:

- **MCPB bundle packaging** — `manifest.json`, `.mcpbignore`, and `.github/workflows/publish-mcpb.yml` package the repo as a Claude Desktop extension (`.mcpb`) on every `v*` tag. Uses `server.type: "uv"` so the bundle is ~85 kB and defers dep resolution to the user's machine. Validates tag ↔ pyproject ↔ manifest version parity and attaches the bundle to the GitHub Release.
- **GitHub-refreshed index tier** — new `src/vipmp_docs_mcp/remote_index.py` fetches `data/index.json` from `main` on raw.githubusercontent.com (12 h TTL, ETag revalidation, atomic writes, stale-OK on any failure). `resolve_active_index()` in `index.py` now walks four tiers: user-local → github-remote → package-baseline → live-extraction. **Merging the daily refresh-index PR now reaches users within 12 h without a PyPI release.** Opt-out via `VIPMP_DISABLE_REMOTE_INDEX=1`.
- `vipmp_server_info` now shows the active tier and remote-index cache state.

## Release status

- Tag `v0.7.0` already pushed → both publish workflows ran green
- [PyPI 0.7.0](https://pypi.org/project/vipmp-docs-mcp/0.7.0/) published
- `vipmp-docs-mcp-0.7.0.mcpb` attached to the GitHub Release

## Test plan

- [x] Ruff clean (`ruff check src/ tests/`)
- [x] All tests pass — 159 total, 21 new (`pytest`)
- [x] `mcpb validate manifest.json` — locally verified
- [x] `mcpb pack .` — locally produces an 85 kB, 21-file bundle
- [x] Both publish workflows succeeded against this commit (tag was cut off this branch)
- [x] Post-merge: confirm a clean CI run on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)