### PR TITLE
v0.7.1 — fix rebuild_vipmp_index crash + sitemap staleness (fixes #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-04-20
+
+### Fixed
+- **`rebuild_vipmp_index` crashed with "asyncio.run() cannot be called
+  from a running event loop"** when invoked as an MCP tool (GitHub
+  issue #4). The inner `asyncio.run` in `build_index()` assumed no
+  surrounding event loop, which is true for CI scripts and the REPL
+  but false for every MCP client (VS Code, Claude Desktop, etc.) where
+  the server runs inside an active loop. Now guarded: if a loop is
+  already running, the parallel fetch is isolated in a short-lived
+  thread with its own fresh loop.
+- **CI-built indexes were mostly empty** because the hand-curated
+  fallback in `sitemap.py` still uses underscore-separated paths
+  (`/vipmp/docs/reseller_account/…`) while Adobe's live docs have
+  migrated to hyphens (`/vipmp/docs/reseller-account/…`). GitHub
+  Actions runners have no persisted `sitemap.json` on first use, so
+  `build_index()` fell back to the stale list → mostly-404 fetches →
+  5-endpoint indexes. The github-remote tier then shipped those to
+  every user. `build_index()` now refreshes the sitemap from Adobe's
+  live XML before fetching pages; if Adobe is unreachable it falls
+  back as before. Follow-up: retire or update the underscore paths
+  in `sitemap.py` — tracked separately.
+
+### Added
+- **Stale-index warning in `vipmp_server_info`.** When the active
+  index has fewer than 30 endpoints (healthy builds carry hundreds),
+  the diagnostic now leads with a `⚠️ index looks incomplete` banner
+  and tells the user to run `rebuild_vipmp_index`. Balint's report
+  (issue #4) was slow to diagnose partly because `5 endpoints`
+  didn't obviously read as broken.
+
+### Internal
+- New regression test: `build_index()` is now exercised from inside
+  `asyncio.run(...)` (pytest-asyncio auto-mode) so the loop-nesting
+  bug can't re-land silently. Added a second test covering the
+  best-effort sitemap refresh: if Adobe's XML is unreachable, the
+  build completes against the currently-active sitemap.
+
 ## [0.7.0] — 2026-04-19
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "vipmp-docs-mcp",
   "display_name": "Adobe VIP Marketplace Docs",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
   "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes — without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/vipmp_docs_mcp/__init__.py
+++ b/src/vipmp_docs_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Adobe VIP Marketplace Docs MCP Server."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/src/vipmp_docs_mcp/index.py
+++ b/src/vipmp_docs_mcp/index.py
@@ -133,10 +133,35 @@ def build_index() -> IndexSnapshot:
 
     Takes ~10s with a warm cache and parallel fetcher (was ~30s serial),
     ~20s cold (was ~60s serial).
+
+    Callable from both synchronous contexts (CI scripts, REPL) and from
+    inside a running event loop (MCP tool handlers). See the fetch call
+    below for the asyncio.run nesting guard.
     """
     import asyncio
+    import concurrent.futures
 
+    from .autositemap import build_sitemap, save_sitemap
     from .fetcher import async_fetch_many
+
+    # Refresh the sitemap from Adobe before doing anything else. The
+    # hand-curated fallback in sitemap.py still uses underscore-separated
+    # paths that Adobe has migrated off (see GitHub issue #4) — rebuilding
+    # against it produces mostly-404 fetches and a near-empty index, which
+    # is exactly how CI-built indexes have been regressing for users on
+    # the github-remote tier. If Adobe's sitemap.xml is unreachable the
+    # refresh is skipped and we fall back to whatever `get_active_sitemap`
+    # finds (persisted JSON first, hand-curated last resort).
+    try:
+        log.info("build_index: refreshing sitemap from Adobe before build")
+        entries = build_sitemap()
+        save_sitemap(entries)
+    except Exception as exc:
+        log.warning(
+            "build_index: sitemap refresh failed (%s); "
+            "proceeding with currently-active sitemap",
+            exc,
+        )
 
     sitemap = get_active_sitemap()
     snap = IndexSnapshot(source_sitemap_size=len(sitemap))
@@ -144,7 +169,22 @@ def build_index() -> IndexSnapshot:
     title_for = {entry["path"]: entry["title"] for entry in sitemap}
 
     log.info("build_index: fetching %d pages in parallel", len(paths))
-    fetch_results = asyncio.run(async_fetch_many(paths, concurrency=5))
+    # Run the parallel fetch whether we're in a sync context (CI, scripts)
+    # or already inside an event loop (MCP tool handler). `asyncio.run()`
+    # can't nest — it raises "cannot be called from a running event loop"
+    # — so when a loop is active we isolate the coroutine in a short-lived
+    # thread with its own fresh loop. The lambda is deliberate: it defers
+    # coroutine construction to the worker thread so no async state is
+    # built under the outer loop's context.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        fetch_results = asyncio.run(async_fetch_many(paths, concurrency=5))
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            fetch_results = pool.submit(
+                lambda: asyncio.run(async_fetch_many(paths, concurrency=5))
+            ).result()
 
     for path in paths:
         result = fetch_results.get(path)

--- a/src/vipmp_docs_mcp/server.py
+++ b/src/vipmp_docs_mcp/server.py
@@ -39,6 +39,14 @@ from .sitemap import normalize_path
 log = get_logger("server")
 
 
+# Threshold below which `vipmp_server_info` flags the active index as
+# suspiciously incomplete. Healthy rebuilds against the current Adobe
+# sitemap carry several hundred endpoints. Anything below this count
+# almost always means the build ran against a stale path list and
+# mostly 404'd. See GitHub issue #4.
+STALE_INDEX_ENDPOINT_THRESHOLD = 30
+
+
 # Active sitemap: auto-generated (from Adobe's sitemap.xml, persisted to
 # ~/.cache/.../sitemap.json) if available, else hand-curated fallback.
 # Mutable so `refresh_vipmp_sitemap` can swap in a fresh copy at runtime
@@ -919,6 +927,17 @@ def vipmp_server_info() -> str:
             f"{len(idx.releases)} releases — "
             f"built {idx.age_seconds / 3600:.1f}h ago"
         )
+        # Flag obviously-broken indexes explicitly. Healthy builds carry
+        # hundreds of endpoints; anything below the threshold almost always
+        # means the sitemap was stale or mostly 404'd at build time
+        # (see GitHub issue #4). Surfacing it in server_info means users
+        # spot the regression without having to know to cross-check.
+        if len(idx.endpoints) < STALE_INDEX_ENDPOINT_THRESHOLD:
+            idx_line = (
+                f"**⚠️ index looks incomplete** ({len(idx.endpoints)} endpoints; "
+                f"healthy builds carry hundreds). Call `rebuild_vipmp_index` to "
+                f"regenerate against the current Adobe sitemap. Details: " + idx_line
+            )
         idx_source_line = f"- **Source:** `{active.source}` (`{active.path}`)"
     else:
         idx_line = "_(no index available — call `rebuild_vipmp_index`)_"

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -14,6 +14,7 @@ from vipmp_docs_mcp.extractors import Endpoint, ErrorCode, SchemaField, SchemaRe
 from vipmp_docs_mcp.index import (
     INDEX_SCHEMA_VERSION,
     IndexSnapshot,
+    build_index,
     load_index,
     resolve_active_index,
     save_index,
@@ -96,6 +97,90 @@ class TestLoadIndex:
         path = tmp_path / "bad.json"
         path.write_text("not json {{{")
         assert load_index(path) is None
+
+
+class TestBuildIndexFromAsyncContext:
+    """
+    Regression for GitHub issue #4 — `build_index()` must work when
+    invoked from an already-running event loop (how MCP tool handlers
+    call it). Before 0.7.1 the inner `asyncio.run()` crashed with
+    "cannot be called from a running event loop".
+
+    This test is `async def`, so pytest-asyncio runs it inside an event
+    loop. If the nesting guard regresses, it'll reappear here before it
+    ships.
+    """
+
+    async def test_build_index_runs_inside_event_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from vipmp_docs_mcp import autositemap
+        from vipmp_docs_mcp import fetcher as fetcher_module
+
+        fake_sitemap = [
+            {"path": "/vipmp/docs/x", "title": "X", "tags": []},
+            {"path": "/vipmp/docs/y", "title": "Y", "tags": []},
+        ]
+
+        # Stub the sitemap refresh path — no network, returns a tiny sitemap.
+        monkeypatch.setattr(autositemap, "build_sitemap", lambda *a, **k: fake_sitemap)
+        monkeypatch.setattr(autositemap, "save_sitemap", lambda *a, **k: None)
+        monkeypatch.setattr(
+            index_module, "get_active_sitemap", lambda: fake_sitemap
+        )
+
+        # Stub the parallel fetch. `build_index` imports async_fetch_many from
+        # `vipmp_docs_mcp.fetcher`, so patch at the source module.
+        async def fake_fetch_many(paths, **_):
+            return dict.fromkeys(paths, "<html><body>vipmp</body></html>")
+
+        monkeypatch.setattr(fetcher_module, "async_fetch_many", fake_fetch_many)
+
+        # Stub the release-notes fetch (called with a sync fetch_page_html).
+        monkeypatch.setattr(
+            index_module,
+            "fetch_page_html",
+            lambda *a, **k: "<html><body></body></html>",
+        )
+
+        # The test itself: this is an async function, so we're inside a
+        # running event loop. Before the fix, build_index() raised
+        # RuntimeError from its inner asyncio.run() call.
+        snap = build_index()
+        assert snap is not None
+        assert snap.source_sitemap_size == len(fake_sitemap)
+
+    async def test_build_index_tolerates_sitemap_refresh_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """If Adobe's sitemap.xml is unreachable, build_index falls back to
+        whatever get_active_sitemap returns rather than raising."""
+        from vipmp_docs_mcp import autositemap
+        from vipmp_docs_mcp import fetcher as fetcher_module
+
+        def fail_refresh(*a, **k):
+            raise RuntimeError("Adobe unreachable")
+
+        fake_sitemap = [{"path": "/vipmp/docs/x", "title": "X", "tags": []}]
+
+        monkeypatch.setattr(autositemap, "build_sitemap", fail_refresh)
+        monkeypatch.setattr(
+            index_module, "get_active_sitemap", lambda: fake_sitemap
+        )
+
+        async def fake_fetch_many(paths, **_):
+            return dict.fromkeys(paths, "<html><body>vipmp</body></html>")
+
+        monkeypatch.setattr(fetcher_module, "async_fetch_many", fake_fetch_many)
+        monkeypatch.setattr(
+            index_module,
+            "fetch_page_html",
+            lambda *a, **k: "<html><body></body></html>",
+        )
+
+        snap = build_index()
+        assert snap is not None
+        assert snap.source_sitemap_size == 1
 
 
 class TestResolveActiveIndex:


### PR DESCRIPTION
Fixes #4.

## Summary

Two bugs working together were shipping broken indexes to every user on the github-remote tier.

**Bug 1 (reported):** \`rebuild_vipmp_index\` crashed with \`asyncio.run() cannot be called from a running event loop\`. The inner \`asyncio.run()\` in \`build_index()\` assumed no surrounding loop — true for CI scripts and the REPL, false for every MCP tool handler. Users couldn't force-refresh their local index.

**Bug 2 (uncovered by investigation):** CI-built indexes were near-empty. The hand-curated fallback in \`sitemap.py\` still uses underscore-separated paths (\`/vipmp/docs/reseller_account/get_reseller_list/\`) while Adobe migrated to hyphens (\`/vipmp/docs/reseller-account/get-reseller-list/\`). GitHub Actions runners have no per-user \`sitemap.json\`, so \`build_index()\` fell back to the stale list, fetched mostly 404s, and shipped a 5-endpoint \`data/index.json\` that the github-remote tier distributed to every PyPI/MCPB user. Explains the reporter's \"Index: 15 pages, 5 endpoints\" symptom.

## Changes

- **\`build_index()\` handles both sync and async-loop contexts.** If an event loop is running, the parallel fetch runs in a short-lived thread with its own fresh loop. \`asyncio.run()\` is still used when no loop is active. Same output, works from anywhere.
- **\`build_index()\` refreshes the sitemap from Adobe before fetching pages.** No more dependence on a pre-persisted \`sitemap.json\`. If Adobe's XML is unreachable the build falls back as before (best-effort).
- **Stale-index warning in \`vipmp_server_info\`.** If the active index has fewer than 30 endpoints, the diagnostic now leads with \`⚠️ index looks incomplete\` and suggests \`rebuild_vipmp_index\`. Makes the symptom reporter hit obvious at a glance.
- **Regression test** that runs \`build_index()\` inside \`asyncio.run(...)\` via pytest-asyncio. The crash can't re-land silently.
- **Second test** covering the best-effort sitemap refresh path (Adobe unreachable → fall back gracefully).

## Deliberately out of scope

Retiring or updating the underscore paths in \`sitemap.py\` itself. Two options (regex-replace, or remove the hand-curated entries entirely and keep only the tag lookup) — each deserves its own focused PR. Filed as follow-up after this merges.

## Test plan

- [x] All 161 tests pass (2 new)
- [x] \`ruff check src/ tests/\` clean
- [x] \`mcpb validate manifest.json\` clean
- [x] Version parity: pyproject.toml, \`__init__.py\`, manifest.json all at 0.7.1
- [ ] Post-merge: tag \`v0.7.1\`, workflows publish to PyPI + attach MCPB to GitHub Release
- [ ] Post-release: reporter confirms \`rebuild_vipmp_index\` works against fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)