### PR TITLE
v0.7.2 — retire stale hand-curated sitemap, ship generated fallback (fixes #6)

### DIFF
--- a/.github/workflows/refresh-index.yml
+++ b/.github/workflows/refresh-index.yml
@@ -44,8 +44,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
 
-      - name: Rebuild index
+      - name: Rebuild sitemap + index
         id: rebuild
+        # build_index() already refreshes the sitemap from Adobe's live XML
+        # internally (fix from #4), but we also persist it to the package
+        # data directory here so fresh installs get a current fallback
+        # shipped with the wheel (#6).
         run: |
           python - <<'PY'
           import json
@@ -53,11 +57,28 @@ jobs:
           import time
           from pathlib import Path
 
-          from vipmp_docs_mcp.index import PACKAGE_INDEX_PATH, build_index, save_index
+          from vipmp_docs_mcp.autositemap import (
+              PACKAGE_SITEMAP_PATH,
+              build_sitemap,
+              save_sitemap,
+          )
+          from vipmp_docs_mcp.index import (
+              PACKAGE_INDEX_PATH,
+              build_index,
+              save_index,
+          )
 
-          start = time.time()
+          # 1) Refresh the shipped sitemap fallback from Adobe.
+          sitemap_start = time.time()
+          sitemap_entries = build_sitemap()
+          save_sitemap(sitemap_entries, PACKAGE_SITEMAP_PATH)
+          sitemap_elapsed = time.time() - sitemap_start
+
+          # 2) Rebuild the structured index. build_index() refreshes the
+          # sitemap again internally; cheap on cache hits thanks to ETags.
+          index_start = time.time()
           snap = build_index()
-          elapsed = time.time() - start
+          index_elapsed = time.time() - index_start
 
           save_index(snap, PACKAGE_INDEX_PATH)
 
@@ -68,7 +89,8 @@ jobs:
               fh.write(f"error_codes={len(snap.error_codes)}\n")
               fh.write(f"schemas={len(snap.schemas)}\n")
               fh.write(f"parse_errors={len(snap.parse_errors)}\n")
-              fh.write(f"elapsed_seconds={elapsed:.1f}\n")
+              fh.write(f"sitemap_elapsed_seconds={sitemap_elapsed:.1f}\n")
+              fh.write(f"index_elapsed_seconds={index_elapsed:.1f}\n")
 
           # Emit error list for the PR body.
           Path("parse-errors.txt").write_text(
@@ -78,14 +100,16 @@ jobs:
           )
           PY
 
-      - name: Check if index changed
+      - name: Check if index or sitemap changed
         id: diff
         run: |
-          # Strip the `built_at` timestamp before diffing — otherwise every
-          # run produces a "change". Compare the structural content only.
+          # Strip timestamps before diffing — otherwise every run produces
+          # noise. Compare structural content only.
           git --no-pager diff --quiet \
               -I '^  "built_at":' \
+              -I '^  "generated_at":' \
               src/vipmp_docs_mcp/data/index.json \
+              src/vipmp_docs_mcp/data/sitemap.json \
             && echo "changed=false" >> "$GITHUB_OUTPUT" \
             || echo "changed=true" >> "$GITHUB_OUTPUT"
 
@@ -94,12 +118,12 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          commit-message: 'chore(index): refresh structured index from Adobe docs'
+          commit-message: 'chore(data): refresh sitemap + structured index from Adobe docs'
           branch: bot/refresh-index
           delete-branch: true
-          title: 'chore(index): refresh structured index from Adobe docs'
+          title: 'chore(data): refresh sitemap + structured index from Adobe docs'
           body: |
-            Automated refresh of `src/vipmp_docs_mcp/data/index.json` from live Adobe docs.
+            Automated refresh of `src/vipmp_docs_mcp/data/sitemap.json` and `src/vipmp_docs_mcp/data/index.json` from live Adobe docs.
 
             **Trigger:** ${{ github.event_name == 'workflow_dispatch' && inputs.reason || 'scheduled (weekly)' }}
 
@@ -113,7 +137,8 @@ jobs:
             | Error codes | ${{ steps.rebuild.outputs.error_codes }} |
             | Schemas | ${{ steps.rebuild.outputs.schemas }} |
             | Parse errors | ${{ steps.rebuild.outputs.parse_errors }} |
-            | Build time | ${{ steps.rebuild.outputs.elapsed_seconds }}s |
+            | Sitemap build time | ${{ steps.rebuild.outputs.sitemap_elapsed_seconds }}s |
+            | Index build time | ${{ steps.rebuild.outputs.index_elapsed_seconds }}s |
 
             ## Parse errors (if any)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] — 2026-04-20
+
+### Changed
+- **Retired the hand-curated path list in `sitemap.py`** (GitHub issue
+  #6). 46 of the 72 entries used underscore-separated slugs that
+  Adobe migrated off, so the list was drifting unusable. The module
+  now ships only what's still valuable: `SitemapEntry`, `normalize_path`,
+  and `CURATED_TAGS` — a `{last-path-segment: [tags]}` dict that
+  `merge_curated_tags` applies to Adobe-sourced entries for richer
+  search recall. Existing search/listing behaviour is preserved because
+  the tag lookup was already keyed on hyphen-normalised last segments.
+- **`get_active_sitemap` has a new tier chain.** Old: per-user cache
+  → hand-curated list. New: per-user cache → package-shipped
+  `data/sitemap.json` → empty. The middle tier is new — a
+  freshly-generated sitemap ships with every wheel so fresh installs
+  get a current sitemap with zero network on first run. Daily CI
+  refreshes it alongside `data/index.json`.
+
+### Added
+- **`src/vipmp_docs_mcp/data/sitemap.json`** — package-shipped
+  sitemap fallback. 86 entries, hyphen paths, curated tags merged.
+  Regenerated daily by `refresh-index.yml`.
+- **`tests/test_autositemap.py`** — covers the new tier chain
+  (user-cache wins, package fallback, corrupt-cache fallthrough,
+  schema mismatch handling) and `merge_curated_tags` behaviour
+  against `CURATED_TAGS`.
+
+### Removed
+- `sitemap.SITEMAP` (retired — was drifting from Adobe's slug
+  convention and is no longer a reliable fallback).
+- `sitemap.known_paths` and `sitemap.find_by_path` (only caller was
+  the hand-curated fallback in server.py, which was retired too).
+- `autositemap._build_curated_tag_index` (folded into
+  `merge_curated_tags` now that the source is a dict, not a list).
+
+### Internal
+- `server._find_by_path` no longer falls back to the hand-curated list
+  (there isn't one anymore). Simpler; returns `None` when the active
+  sitemap doesn't contain the path, and callers already tolerated that.
+- `refresh-index.yml` now regenerates `data/sitemap.json` before the
+  index rebuild and includes both in the bot-authored PR. Diff
+  detection ignores timestamps on both files.
+
 ## [0.7.1] — 2026-04-20
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "vipmp-docs-mcp",
   "display_name": "Adobe VIP Marketplace Docs",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
   "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes — without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.7.1"
+version = "0.7.2"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/vipmp_docs_mcp/__init__.py
+++ b/src/vipmp_docs_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Adobe VIP Marketplace Docs MCP Server."""
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/src/vipmp_docs_mcp/autositemap.py
+++ b/src/vipmp_docs_mcp/autositemap.py
@@ -3,11 +3,20 @@ Auto-refresh the docs sitemap from Adobe's published sitemap.xml.
 
 Adobe publishes `/sitemap.xml` listing every URL under developer.adobe.com.
 We filter for `/vipmp/docs/` paths, fetch each page for its title, and build
-a fresh `SitemapEntry` list. Tags are derived from path segments + the
-hand-curated tag dictionary in `sitemap_tags.py`.
+a fresh `SitemapEntry` list. Tags come from two sources: light-touch
+derivation from path segments + the human-curated ``CURATED_TAGS`` dict
+in [sitemap.py](./sitemap.py) merged in for richer recall.
 
-The auto-generated sitemap is persisted to `sitemap.json` in the cache dir
-so subsequent server startups don't need to refetch.
+Resolution chain for the active sitemap (see ``get_active_sitemap``):
+
+    1. Per-user persisted sitemap (``~/.cache/.../sitemap.json``) — freshest,
+       written by ``refresh_vipmp_sitemap`` and ``build_index``.
+    2. Package-shipped sitemap (``src/vipmp_docs_mcp/data/sitemap.json``) —
+       regenerated from Adobe by the daily CI refresh workflow, published
+       with each release. Guarantees fresh installs have a working sitemap
+       immediately, without a network round-trip.
+    3. Empty list — last-resort. Callers handle gracefully (search returns
+       nothing, describe tools fall back to on-the-fly extraction).
 """
 
 from __future__ import annotations
@@ -22,13 +31,17 @@ from bs4 import BeautifulSoup
 
 from .fetcher import BASE_URL, FetchError, fetch_page_html
 from .logging_config import CACHE_DIR, get_logger
-from .sitemap import SITEMAP as HAND_CURATED_SITEMAP
-from .sitemap import SitemapEntry, normalize_path
+from .sitemap import CURATED_TAGS, SitemapEntry, normalize_path
 
 log = get_logger("autositemap")
 
 SITEMAP_XML_PATH = "/sitemap.xml"
 SITEMAP_JSON_PATH = CACHE_DIR / "sitemap.json"
+
+# Package-shipped fallback sitemap, regenerated from Adobe by the daily
+# refresh workflow and bundled with the wheel. Fresh installs land here
+# before they've persisted a user-specific sitemap.
+PACKAGE_SITEMAP_PATH = Path(__file__).parent / "data" / "sitemap.json"
 
 # Schema version — bump on breaking changes to the persisted JSON shape.
 SITEMAP_SCHEMA_VERSION = 1
@@ -88,39 +101,22 @@ def _derive_tags(path: str, title: str) -> list[str]:
     return sorted(tags)
 
 
-def _build_curated_tag_index() -> dict[str, list[str]]:
-    """
-    Build a lookup from base path-suffix → curated tags, using the legacy
-    hand-curated SITEMAP. This lets us reuse the richer tags (like "3YC",
-    "HGO", "x-correlation-id") even though Adobe's URLs have changed.
-
-    Key is the last non-empty path segment lowercased with hyphens → e.g.
-    "/vipmp/docs/customer_account/three_year_commit/" keys as "three-year-commit".
-    """
-    index: dict[str, list[str]] = {}
-    for entry in HAND_CURATED_SITEMAP:
-        # Normalize the legacy path segment to hyphen convention.
-        segments = [s for s in entry["path"].strip("/").split("/") if s]
-        if not segments:
-            continue
-        last = segments[-1].replace("_", "-").lower()
-        index[last] = list(entry["tags"])
-    return index
-
-
 def merge_curated_tags(entries: list[SitemapEntry]) -> list[SitemapEntry]:
-    """Merge hand-curated tags onto auto-generated entries where paths line up."""
-    curated = _build_curated_tag_index()
+    """
+    Merge curated tags (``CURATED_TAGS`` in sitemap.py) onto auto-generated
+    entries. Keys on the last non-empty path segment lowercased — e.g. an
+    entry at ``/vipmp/docs/customer-account/three-year-commit`` picks up
+    the tags keyed under ``three-year-commit``.
+    """
     merged = 0
     for entry in entries:
         segments = [s for s in entry["path"].strip("/").split("/") if s]
         if not segments:
             continue
         last = segments[-1].lower()
-        if last in curated:
+        if last in CURATED_TAGS:
             existing = set(entry["tags"])
-            for tag in curated[last]:
-                existing.add(tag)
+            existing.update(CURATED_TAGS[last])
             entry["tags"] = sorted(existing)
             merged += 1
     log.info("merged curated tags onto %d/%d entries", merged, len(entries))
@@ -199,11 +195,23 @@ def load_sitemap(path: Path = SITEMAP_JSON_PATH) -> list[SitemapEntry] | None:
 
 def get_active_sitemap() -> list[SitemapEntry]:
     """
-    Return the sitemap the server should use — persisted auto-generated one
-    if available, hand-curated fallback otherwise.
+    Return the sitemap the server should use, walking the tier chain:
+
+    1. Per-user persisted sitemap (``~/.cache/.../sitemap.json``) — freshest.
+    2. Package-shipped sitemap (``src/vipmp_docs_mcp/data/sitemap.json``) —
+       bundled with the wheel, regenerated daily by CI.
+    3. Empty list — last-resort. The hand-curated path list that used to
+       live here was retired in 0.7.2 (GitHub issue #6) after Adobe
+       migrated from underscore- to hyphen-separated slugs.
     """
-    auto = load_sitemap()
-    if auto:
-        return auto
-    log.info("no persisted sitemap; falling back to hand-curated")
-    return HAND_CURATED_SITEMAP
+    user = load_sitemap(SITEMAP_JSON_PATH)
+    if user:
+        return user
+    package = load_sitemap(PACKAGE_SITEMAP_PATH)
+    if package:
+        log.debug("no per-user sitemap; using package-shipped fallback")
+        return package
+    log.warning("no sitemap available (user cache missing and package "
+                "fallback unreadable) — search and listing tools will "
+                "return empty results until `refresh_vipmp_sitemap` runs")
+    return []

--- a/src/vipmp_docs_mcp/data/sitemap.json
+++ b/src/vipmp_docs_mcp/data/sitemap.json
@@ -1,0 +1,1264 @@
+{
+  "schema_version": 1,
+  "generated_at": 1776687510.118525,
+  "entries": [
+    {
+      "path": "/vipmp/docs",
+      "title": "Introduction",
+      "tags": [
+        "customer",
+        "distributor",
+        "introduction",
+        "order flow",
+        "overview",
+        "reseller",
+        "workflow"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/archive/3yc",
+      "title": "Manage Three-Year Commits",
+      "tags": [
+        "3yc",
+        "archive",
+        "commits",
+        "manage",
+        "three",
+        "year"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/authentication",
+      "title": "Identity management and authentication",
+      "tags": [
+        "access",
+        "auth",
+        "authentication",
+        "credentials",
+        "identity",
+        "management",
+        "oauth",
+        "token"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/authentication/health-check",
+      "title": "Health check",
+      "tags": [
+        "authentication",
+        "check",
+        "connectivity",
+        "health",
+        "health check",
+        "ping",
+        "status"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/authentication/oauth-credentials",
+      "title": "Generate OAuth credentials",
+      "tags": [
+        "authentication",
+        "client id",
+        "client secret",
+        "credentials",
+        "generate",
+        "oauth",
+        "oauth credentials",
+        "token"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account",
+      "title": "Manage customer accounts",
+      "tags": [
+        "account",
+        "accounts",
+        "customer",
+        "customer account",
+        "manage",
+        "overview"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/create-customer-account",
+      "title": "Create customer account",
+      "tags": [
+        "POST",
+        "account",
+        "create",
+        "create customer account",
+        "customer",
+        "customer account",
+        "new customer"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/get-customer-account",
+      "title": "Get customer account details",
+      "tags": [
+        "GET",
+        "account",
+        "account details",
+        "customer",
+        "customer account",
+        "details",
+        "get",
+        "get customer account",
+        "retrieve"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/get-customer-list",
+      "title": "Get customer list",
+      "tags": [
+        "GET",
+        "account",
+        "all customers",
+        "customer",
+        "customer account",
+        "get",
+        "get customer list",
+        "list",
+        "pagination"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/get-licenses",
+      "title": "Get licenses pending partner order",
+      "tags": [
+        "GET",
+        "account",
+        "customer",
+        "customer account",
+        "customer licenses",
+        "get",
+        "get licenses",
+        "licenses",
+        "order",
+        "partner",
+        "partner order",
+        "pending"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/high-growth",
+      "title": "Manage High Growth Offers",
+      "tags": [
+        "HGO",
+        "account",
+        "customer",
+        "customer account",
+        "growth",
+        "growth offer",
+        "high",
+        "high growth",
+        "manage",
+        "offers"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/high-growth-apis",
+      "title": "Manage High Growth Offers through APIs",
+      "tags": [
+        "API",
+        "HGO",
+        "account",
+        "apis",
+        "customer",
+        "customer account",
+        "growth",
+        "high",
+        "high growth",
+        "high growth apis",
+        "manage",
+        "offers",
+        "through"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/high-growth-scenarios",
+      "title": "High Growth Offer scenarios",
+      "tags": [
+        "HGO",
+        "account",
+        "customer",
+        "customer account",
+        "examples",
+        "growth",
+        "high",
+        "high growth",
+        "high growth scenarios",
+        "offer",
+        "scenarios"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/linked-membership",
+      "title": "Manage Linked Memberships",
+      "tags": [
+        "account",
+        "consolidation",
+        "customer",
+        "customer account",
+        "link",
+        "linked",
+        "linked membership",
+        "manage",
+        "membership",
+        "memberships"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/market-segment",
+      "title": "Manage market segments",
+      "tags": [
+        "account",
+        "customer",
+        "customer account",
+        "manage",
+        "market",
+        "market segment",
+        "segment",
+        "segments"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/three-year-commit",
+      "title": "Manage Three-Year Commits",
+      "tags": [
+        "3YC",
+        "account",
+        "commit",
+        "commitment",
+        "commits",
+        "customer",
+        "customer account",
+        "manage",
+        "price lock",
+        "three",
+        "three year commit",
+        "year"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/customer-account/update-customer-account",
+      "title": "Update customer account",
+      "tags": [
+        "PATCH",
+        "PUT",
+        "account",
+        "customer",
+        "customer account",
+        "modify",
+        "update",
+        "update customer account"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/deployment-management",
+      "title": "Manage deployments",
+      "tags": [
+        "deployment",
+        "deployment management",
+        "deployments",
+        "manage",
+        "management",
+        "overview"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/deployment-management/create-deployment",
+      "title": "Create deployments",
+      "tags": [
+        "POST",
+        "create",
+        "create deployment",
+        "deployment",
+        "deployment management",
+        "deployments",
+        "management"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/deployment-management/get-deployment",
+      "title": "Get deployment details",
+      "tags": [
+        "GET",
+        "deployment",
+        "deployment management",
+        "details",
+        "get",
+        "get deployment",
+        "management"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/deployment-management/update-deployment",
+      "title": "Update a deployment of customer",
+      "tags": [
+        "PATCH",
+        "PUT",
+        "customer",
+        "deployment",
+        "deployment management",
+        "management",
+        "modify",
+        "update",
+        "update deployment"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/flex-discounts",
+      "title": "Manage Flexible Discounts",
+      "tags": [
+        "discount",
+        "discounts",
+        "flex",
+        "flex discount",
+        "flex discounts",
+        "flexible",
+        "flexible discounts",
+        "manage"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/flex-discounts/apis",
+      "title": "Manage Flexible Discounts using APIs",
+      "tags": [
+        "API",
+        "apis",
+        "discounts",
+        "flex",
+        "flex discounts",
+        "flexible",
+        "manage",
+        "mid-term",
+        "upgrade",
+        "using"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/flex-discounts/error-codes",
+      "title": "Error codes specific to Flexible Discounts",
+      "tags": [
+        "1117",
+        "1118",
+        "1147",
+        "1163",
+        "1164",
+        "1167",
+        "1168",
+        "5117",
+        "LGA",
+        "codes",
+        "discounts",
+        "error",
+        "error codes",
+        "errors",
+        "flex",
+        "flex discounts",
+        "flexible",
+        "large government agency",
+        "specific"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/flex-discounts/flex-discount-apis",
+      "title": "Flexible Discount API",
+      "tags": [
+        "api",
+        "apis",
+        "discount",
+        "discounts",
+        "flex",
+        "flex discount apis",
+        "flex discounts",
+        "flexible"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/lga",
+      "title": "Manage Large Government Agencies",
+      "tags": [
+        "Canada",
+        "GOV",
+        "LGA",
+        "US",
+        "agencies",
+        "discount",
+        "federal",
+        "government",
+        "large",
+        "large government agency",
+        "lga",
+        "linked membership",
+        "manage",
+        "state"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/lga/convert",
+      "title": "Convert an existing government customer to LGA",
+      "tags": [
+        "AD",
+        "GOV",
+        "LGA",
+        "PATCH",
+        "PENDING_UPGRADE",
+        "anniversary date",
+        "convert",
+        "customer",
+        "existing",
+        "government",
+        "large government agency",
+        "lga",
+        "renewal"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/lga/create",
+      "title": "Create an LGA customer",
+      "tags": [
+        "FEDERAL",
+        "LGA",
+        "POST",
+        "STATE",
+        "create",
+        "customer",
+        "enroll",
+        "large government agency",
+        "lga",
+        "linked membership",
+        "marketSubSegments"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/lga/error-codes",
+      "title": "Error codes specific to LGA",
+      "tags": [
+        "1117",
+        "1118",
+        "1147",
+        "1163",
+        "1164",
+        "1167",
+        "1168",
+        "5117",
+        "LGA",
+        "codes",
+        "error",
+        "error codes",
+        "errors",
+        "large government agency",
+        "lga",
+        "specific"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/lga/migrate",
+      "title": "Migrate LGA customers from VIP to VIP Marketplace",
+      "tags": [
+        "FRL",
+        "LGA",
+        "VIP",
+        "customers",
+        "from",
+        "large government agency",
+        "lga",
+        "marketplace",
+        "migrate",
+        "migration",
+        "preview",
+        "transfer",
+        "vip"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/lga/references",
+      "title": "References",
+      "tags": [
+        "LGA",
+        "large government agency",
+        "lga",
+        "references"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/manage-pricing",
+      "title": "Access Price Lists",
+      "tags": [
+        "3YC",
+        "POST",
+        "access",
+        "currency",
+        "lists",
+        "manage",
+        "manage pricing",
+        "offers",
+        "price",
+        "price list",
+        "pricelist",
+        "pricing",
+        "three-year commit"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/market-segments",
+      "title": "Manage market segments",
+      "tags": [
+        "commercial",
+        "education",
+        "government",
+        "manage",
+        "market",
+        "market segments",
+        "segment",
+        "segments"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/mid-term",
+      "title": "Mid-term upgrades",
+      "tags": [
+        "mid",
+        "mid term",
+        "mid-term",
+        "term",
+        "upgrade",
+        "upgrades",
+        "upsize"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/mid-term/apis",
+      "title": "Manage mid-term upgrades through APIs",
+      "tags": [
+        "API",
+        "apis",
+        "manage",
+        "mid",
+        "mid term",
+        "mid-term",
+        "term",
+        "through",
+        "upgrade",
+        "upgrades"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/mid-term/error-codes",
+      "title": "Error codes specific to mid-term upgrade",
+      "tags": [
+        "1117",
+        "1118",
+        "1147",
+        "1163",
+        "1164",
+        "1167",
+        "1168",
+        "5117",
+        "LGA",
+        "codes",
+        "error",
+        "error codes",
+        "errors",
+        "large government agency",
+        "mid",
+        "mid term",
+        "specific",
+        "term",
+        "upgrade"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/mid-term/faq",
+      "title": "Frequently asked questions",
+      "tags": [
+        "FAQ",
+        "asked",
+        "faq",
+        "frequently",
+        "mid",
+        "mid term",
+        "mid-term",
+        "questions",
+        "term",
+        "upgrade"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/migration",
+      "title": "Migrate from VIP to VIP-MP",
+      "tags": [
+        "VIP",
+        "classic VIP",
+        "from",
+        "migrate",
+        "migration",
+        "transfer",
+        "vip"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/migration/get-transfer-details",
+      "title": "Get transfer details",
+      "tags": [
+        "GET",
+        "details",
+        "get",
+        "get transfer details",
+        "migration",
+        "transfer"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/migration/migrate-hvd",
+      "title": "Migrate High Volume Discount customers from VIP to VIP Marketplace",
+      "tags": [
+        "HVD",
+        "VIP to VIP MP",
+        "customers",
+        "discount",
+        "from",
+        "high",
+        "high volume discount",
+        "hvd",
+        "marketplace",
+        "migrate",
+        "migrate hvd",
+        "migration",
+        "vip",
+        "volume"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/migration/preview-offers",
+      "title": "Preview offers",
+      "tags": [
+        "eligibility",
+        "migration",
+        "offers",
+        "preview",
+        "preview offers"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/migration/transfer-subscription",
+      "title": "Transfer subscriptions",
+      "tags": [
+        "POST",
+        "migration",
+        "subscription",
+        "subscriptions",
+        "transfer",
+        "transfer subscription"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/notification-management",
+      "title": "Manage notifications",
+      "tags": [
+        "callback",
+        "event",
+        "manage",
+        "management",
+        "notification",
+        "notification management",
+        "notifications",
+        "push",
+        "webhook"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/order-management",
+      "title": "Manage orders",
+      "tags": [
+        "cancel",
+        "manage",
+        "management",
+        "order",
+        "order management",
+        "orders",
+        "overview"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/order-management/create-order",
+      "title": "Create order",
+      "tags": [
+        "POST",
+        "create",
+        "create order",
+        "management",
+        "new order",
+        "order",
+        "order management",
+        "purchase"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/order-management/get-order",
+      "title": "Get order details",
+      "tags": [
+        "GET",
+        "details",
+        "get",
+        "get order",
+        "management",
+        "order",
+        "order management",
+        "retrieve"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/order-management/invoice",
+      "title": "Pricing and invoicing data",
+      "tags": [
+        "data",
+        "invoice",
+        "invoicing",
+        "management",
+        "order",
+        "order management",
+        "pricing"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/order-management/order-scenarios",
+      "title": "Order creation scenarios",
+      "tags": [
+        "creation",
+        "examples",
+        "management",
+        "new",
+        "order",
+        "order management",
+        "order scenarios",
+        "renewal",
+        "return",
+        "scenarios",
+        "use cases"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/order-management/update-order",
+      "title": "Update order",
+      "tags": [
+        "PATCH",
+        "PUT",
+        "cancel",
+        "management",
+        "modify",
+        "order",
+        "order management",
+        "update",
+        "update order"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/recommendations",
+      "title": "Manage Recommendations",
+      "tags": [
+        "cross-sell",
+        "manage",
+        "recommendations",
+        "upsell"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/recommendations/apis",
+      "title": "Manage Recommendations using APIs",
+      "tags": [
+        "API",
+        "apis",
+        "manage",
+        "mid-term",
+        "recommendations",
+        "upgrade",
+        "using"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/recommendations/error-codes",
+      "title": "Error codes specific to Recommendations",
+      "tags": [
+        "1117",
+        "1118",
+        "1147",
+        "1163",
+        "1164",
+        "1167",
+        "1168",
+        "5117",
+        "LGA",
+        "codes",
+        "error",
+        "error codes",
+        "errors",
+        "large government agency",
+        "recommendations",
+        "specific"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/recommendations/recommendations-apis",
+      "title": "Recommendations API",
+      "tags": [
+        "api",
+        "apis",
+        "recommendations",
+        "recommendations apis"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references",
+      "title": "References",
+      "tags": [
+        "LGA",
+        "large government agency",
+        "references"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references/api-headers",
+      "title": "Request header",
+      "tags": [
+        "api",
+        "api headers",
+        "authorization",
+        "content-type",
+        "header",
+        "headers",
+        "references",
+        "request",
+        "request headers",
+        "x-api-key"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references/error-handling",
+      "title": "Status codes and error handling",
+      "tags": [
+        "codes",
+        "error",
+        "error codes",
+        "error handling",
+        "errors",
+        "handling",
+        "references",
+        "status",
+        "status codes",
+        "troubleshooting"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references/idempotency",
+      "title": "Idempotency – Correlation ID Header",
+      "tags": [
+        "correlation",
+        "correlation id",
+        "duplicate requests",
+        "header",
+        "idempotency",
+        "references",
+        "x-correlation-id"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references/resources",
+      "title": "Resources and fields",
+      "tags": [
+        "data model",
+        "fields",
+        "object reference",
+        "references",
+        "resources",
+        "schema"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references/status-codes",
+      "title": "HTTP status codes",
+      "tags": [
+        "200",
+        "400",
+        "404",
+        "500",
+        "HTTP status codes",
+        "codes",
+        "error",
+        "http",
+        "references",
+        "response codes",
+        "status",
+        "status codes"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references/supported-locales",
+      "title": "Supported Countries and Locales",
+      "tags": [
+        "countries",
+        "currency",
+        "locales",
+        "references",
+        "region",
+        "supported",
+        "supported locales"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/references/validations",
+      "title": "Validations and regular expressions",
+      "tags": [
+        "expressions",
+        "field validation",
+        "format",
+        "references",
+        "regex",
+        "regular",
+        "regular expressions",
+        "validation",
+        "validations"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/release-notes",
+      "title": "Release notes",
+      "tags": [
+        "changelog",
+        "notes",
+        "recent",
+        "release",
+        "release notes",
+        "updates"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/release-notes/fy24",
+      "title": "2024 releases",
+      "tags": [
+        "2024",
+        "fy24",
+        "notes",
+        "release",
+        "release notes",
+        "releases"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/release-notes/upcoming-releases",
+      "title": "Upcoming releases",
+      "tags": [
+        "future",
+        "notes",
+        "release",
+        "release notes",
+        "releases",
+        "roadmap",
+        "upcoming",
+        "upcoming releases"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/renewals/auto-renewals",
+      "title": "Manage auto-renewals using APIs",
+      "tags": [
+        "apis",
+        "auto",
+        "auto renewals",
+        "manage",
+        "renewals",
+        "using"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/renewals/error-codes",
+      "title": "Error codes specific to early renewals",
+      "tags": [
+        "1117",
+        "1118",
+        "1147",
+        "1163",
+        "1164",
+        "1167",
+        "1168",
+        "5117",
+        "LGA",
+        "codes",
+        "early",
+        "error",
+        "error codes",
+        "errors",
+        "large government agency",
+        "renewals",
+        "specific"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/renewals/manual-renewals",
+      "title": "Manage manual renewals using APIs",
+      "tags": [
+        "apis",
+        "manage",
+        "manual",
+        "manual renewals",
+        "renewals",
+        "using"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/renewals/overview",
+      "title": "Manage renewals",
+      "tags": [
+        "manage",
+        "overview",
+        "renewals"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-account",
+      "title": "Manage reseller accounts",
+      "tags": [
+        "account",
+        "accounts",
+        "distributor",
+        "manage",
+        "partner",
+        "reseller",
+        "reseller account"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-account/create-reseller-account",
+      "title": "Create a reseller account",
+      "tags": [
+        "POST",
+        "account",
+        "create",
+        "create reseller account",
+        "new reseller",
+        "reseller",
+        "reseller account"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-account/get-reseller-account",
+      "title": "Get reseller account details",
+      "tags": [
+        "GET",
+        "account",
+        "account details",
+        "details",
+        "get",
+        "get reseller account",
+        "reseller",
+        "reseller account",
+        "retrieve"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-account/get-reseller-list",
+      "title": "Get reseller list",
+      "tags": [
+        "GET",
+        "account",
+        "all resellers",
+        "get",
+        "get reseller list",
+        "list",
+        "pagination",
+        "reseller",
+        "reseller account"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-account/update-reseller-account",
+      "title": "Update a reseller account",
+      "tags": [
+        "PATCH",
+        "PUT",
+        "account",
+        "modify",
+        "reseller",
+        "reseller account",
+        "update",
+        "update reseller account"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-change",
+      "title": "Reseller change process",
+      "tags": [
+        "change",
+        "change reseller",
+        "process",
+        "reseller",
+        "reseller change",
+        "reseller transfer",
+        "transfer"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-change/commit-transfer",
+      "title": "Commit a reseller transfer",
+      "tags": [
+        "POST",
+        "change",
+        "commit",
+        "commit transfer",
+        "reseller",
+        "reseller change",
+        "reseller transfer",
+        "transfer"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-change/get-transfer",
+      "title": "Get reseller transfer details",
+      "tags": [
+        "GET",
+        "change",
+        "details",
+        "get",
+        "get transfer",
+        "reseller",
+        "reseller change",
+        "reseller transfer",
+        "transfer"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/reseller-change/preview-transfer",
+      "title": "Preview a reseller transfer",
+      "tags": [
+        "GET",
+        "change",
+        "preview",
+        "preview transfer",
+        "reseller",
+        "reseller change",
+        "reseller transfer",
+        "transfer"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/resources",
+      "title": "Manage resources",
+      "tags": [
+        "data model",
+        "fields",
+        "manage",
+        "object reference",
+        "resources",
+        "schema"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/resources/processes",
+      "title": "Manage business processes",
+      "tags": [
+        "business",
+        "manage",
+        "processes",
+        "resources"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/resources/workflows",
+      "title": "Manage operational workflows",
+      "tags": [
+        "manage",
+        "operational",
+        "resources",
+        "workflows"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/subscription-management",
+      "title": "Manage subscriptions",
+      "tags": [
+        "auto-renewal",
+        "manage",
+        "management",
+        "overview",
+        "subscription",
+        "subscription management",
+        "subscriptions"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/subscription-management/create-subscription",
+      "title": "Create subscription",
+      "tags": [
+        "POST",
+        "create",
+        "create subscription",
+        "management",
+        "subscription",
+        "subscription management"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/subscription-management/get-details",
+      "title": "Get details of a specific subscription",
+      "tags": [
+        "GET",
+        "details",
+        "get",
+        "get details",
+        "management",
+        "single",
+        "specific",
+        "subscription",
+        "subscription management"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/subscription-management/get-details-for-customers",
+      "title": "Get details of a customer's subscriptions",
+      "tags": [
+        "GET",
+        "all",
+        "customer",
+        "customer subscriptions",
+        "customers",
+        "details",
+        "for",
+        "get",
+        "get details for customers",
+        "list",
+        "management",
+        "subscription",
+        "subscription management",
+        "subscriptions"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/subscription-management/update-subscription",
+      "title": "Update subscription",
+      "tags": [
+        "PATCH",
+        "PUT",
+        "auto-renewal",
+        "management",
+        "modify",
+        "quantity",
+        "subscription",
+        "subscription management",
+        "update",
+        "update subscription"
+      ]
+    },
+    {
+      "path": "/vipmp/docs/support",
+      "title": "Support",
+      "tags": [
+        "contact",
+        "help",
+        "support"
+      ]
+    }
+  ]
+}

--- a/src/vipmp_docs_mcp/server.py
+++ b/src/vipmp_docs_mcp/server.py
@@ -33,7 +33,6 @@ from .index import (
 from .logging_config import configure_logging, get_logger
 from .prompts import register_prompts
 from .search import relevant_sections, search
-from .sitemap import find_by_path as _find_in_hand_curated
 from .sitemap import normalize_path
 
 log = get_logger("server")
@@ -60,13 +59,12 @@ def _get_sitemap():
 
 
 def _find_by_path(path: str):
-    """Find an entry in the active sitemap (may be auto or hand-curated)."""
+    """Find an entry in the active sitemap, or None if absent."""
     normalized = normalize_path(path)
     for entry in _active_sitemap:
         if normalize_path(entry["path"]) == normalized:
             return entry
-    # Fallback: legacy hand-curated list in case the active one is empty.
-    return _find_in_hand_curated(path)
+    return None
 
 
 def _known_paths() -> set[str]:

--- a/src/vipmp_docs_mcp/sitemap.py
+++ b/src/vipmp_docs_mcp/sitemap.py
@@ -1,13 +1,23 @@
 """
-Sitemap of Adobe VIP Marketplace Partner API documentation.
+Hand-authored metadata that complements Adobe's live sitemap.
 
-Currently hand-curated. Phase 4 will add auto-refresh from the docs nav tree
-and allow loading from a persisted `sitemap.json`.
+Originally this module held a full hand-curated list of doc paths. That list
+drifted once Adobe migrated their slug convention from underscores to
+hyphens — see GitHub issue #6. The path list is now retired and replaced by
+two narrow data structures:
 
-Each entry:
-    path:  Absolute docs path (starts with "/vipmp/docs/")
-    title: Human-readable page title
-    tags:  Extra search terms to improve recall on keyword matches
+* ``SitemapEntry`` — the TypedDict shape every other module expects for a
+  sitemap entry, preserved here as a shared vocabulary.
+* ``CURATED_TAGS`` — a ``{last-path-segment: [tags, ...]}`` dict used by
+  ``autositemap.merge_curated_tags`` to add semantic tags (e.g. "3YC",
+  "LGA", "HGO") onto entries Adobe sources. The live sitemap arrives
+  from Adobe's ``/sitemap.xml`` via [autositemap.py](./autositemap.py);
+  the tags below are what we contribute on top.
+
+Adding entries here improves search recall by giving pages extra keywords
+the title alone doesn't carry. Keys must match the page's final path
+segment (hyphens, lowercase). Tag ordering is irrelevant — search treats
+them as a set.
 """
 
 from __future__ import annotations
@@ -21,393 +31,82 @@ class SitemapEntry(TypedDict):
     tags: list[str]
 
 
-SITEMAP: list[SitemapEntry] = [
-    # Introduction / Release notes
-    {
-        "path": "/vipmp/docs/",
-        "title": "Introduction",
-        "tags": ["overview", "introduction", "workflow", "order flow", "distributor", "reseller", "customer"],
-    },
-    {
-        "path": "/vipmp/docs/release_notes/",
-        "title": "Release Notes — Recent",
-        "tags": ["release notes", "changelog", "recent", "updates"],
-    },
-    {
-        "path": "/vipmp/docs/release_notes/upcoming_releases/",
-        "title": "Release Notes — Upcoming",
-        "tags": ["release notes", "upcoming", "roadmap", "future"],
-    },
-
-    # Authentication
-    {
-        "path": "/vipmp/docs/authentication/",
-        "title": "API Authentication and Access",
-        "tags": ["authentication", "auth", "access", "oauth", "credentials", "token"],
-    },
-    {
-        "path": "/vipmp/docs/authentication/health_check/",
-        "title": "Health Check",
-        "tags": ["health check", "ping", "status", "connectivity"],
-    },
-    {
-        "path": "/vipmp/docs/authentication/oauth_credentials/",
-        "title": "Generate OAuth Credentials",
-        "tags": ["oauth", "credentials", "token", "client id", "client secret", "authentication"],
-    },
-
-    # Reseller accounts
-    {
-        "path": "/vipmp/docs/reseller_account/",
-        "title": "Reseller Accounts — Overview",
-        "tags": ["reseller", "account", "partner", "distributor"],
-    },
-    {
-        "path": "/vipmp/docs/reseller_account/create_reseller_account/",
-        "title": "Create a Reseller Account",
-        "tags": ["reseller", "create", "POST", "account", "new reseller"],
-    },
-    {
-        "path": "/vipmp/docs/reseller_account/get_reseller_account/",
-        "title": "Get Reseller Account Details",
-        "tags": ["reseller", "get", "GET", "account details", "retrieve"],
-    },
-    {
-        "path": "/vipmp/docs/reseller_account/get_reseller_list/",
-        "title": "Get Reseller List",
-        "tags": ["reseller", "list", "GET", "all resellers", "pagination"],
-    },
-    {
-        "path": "/vipmp/docs/reseller_account/update_reseller_account/",
-        "title": "Update a Reseller Account",
-        "tags": ["reseller", "update", "PATCH", "PUT", "modify"],
-    },
-
-    # Customer accounts
-    {
-        "path": "/vipmp/docs/customer_account/",
-        "title": "Customer Accounts — Overview",
-        "tags": ["customer", "account", "overview"],
-    },
-    {
-        "path": "/vipmp/docs/market_segments/",
-        "title": "Market Segments",
-        "tags": ["market segments", "commercial", "education", "government", "segment"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/create_customer_account/",
-        "title": "Create Customer Account",
-        "tags": ["customer", "create", "POST", "new customer", "account"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/get_customer_account/",
-        "title": "Get Customer Account Details",
-        "tags": ["customer", "get", "GET", "account details", "retrieve"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/get_customer_list/",
-        "title": "Get Customer List",
-        "tags": ["customer", "list", "GET", "all customers", "pagination"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/update_customer_account/",
-        "title": "Update Customer Account",
-        "tags": ["customer", "update", "PATCH", "PUT", "modify"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/get_licenses/",
-        "title": "Get Licenses Pending Partner Order",
-        "tags": ["licenses", "pending", "GET", "customer licenses", "partner order"],
-    },
-
-    # Deployments
-    {
-        "path": "/vipmp/docs/deployment_management/",
-        "title": "Deployments — Overview",
-        "tags": ["deployment", "overview"],
-    },
-    {
-        "path": "/vipmp/docs/deployment_management/create_deployment/",
-        "title": "Create Deployment",
-        "tags": ["deployment", "create", "POST"],
-    },
-    {
-        "path": "/vipmp/docs/deployment_management/get_deployment/",
-        "title": "Get Deployment Details",
-        "tags": ["deployment", "get", "GET", "details"],
-    },
-    {
-        "path": "/vipmp/docs/deployment_management/update_deployment/",
-        "title": "Update a Deployment",
-        "tags": ["deployment", "update", "PATCH", "PUT", "modify"],
-    },
-
-    # Orders
-    {
-        "path": "/vipmp/docs/order_management/",
-        "title": "Orders — Overview",
-        "tags": ["order", "overview", "cancel"],
-    },
-    {
-        "path": "/vipmp/docs/order_management/create_order/",
-        "title": "Create Order",
-        "tags": ["order", "create", "POST", "new order", "purchase"],
-    },
-    {
-        "path": "/vipmp/docs/order_management/order_scenarios/",
-        "title": "Order Creation Scenarios",
-        "tags": ["order", "scenarios", "examples", "use cases", "new", "renewal", "return"],
-    },
-    {
-        "path": "/vipmp/docs/order_management/get_order/",
-        "title": "Get Order Details",
-        "tags": ["order", "get", "GET", "details", "retrieve"],
-    },
-    {
-        "path": "/vipmp/docs/order_management/update_order/",
-        "title": "Update Order",
-        "tags": ["order", "update", "PATCH", "PUT", "cancel", "modify"],
-    },
-
-    # Subscriptions
-    {
-        "path": "/vipmp/docs/subscription_management/",
-        "title": "Subscriptions — Overview",
-        "tags": ["subscription", "overview", "auto-renewal"],
-    },
-    {
-        "path": "/vipmp/docs/subscription_management/create_subscription/",
-        "title": "Create Subscription",
-        "tags": ["subscription", "create", "POST"],
-    },
-    {
-        "path": "/vipmp/docs/subscription_management/get_details/",
-        "title": "Get Details of a Specific Subscription",
-        "tags": ["subscription", "get", "GET", "details", "single"],
-    },
-    {
-        "path": "/vipmp/docs/subscription_management/get_details_for_customers/",
-        "title": "Get All Subscriptions for a Customer",
-        "tags": ["subscription", "list", "GET", "customer subscriptions", "all"],
-    },
-    {
-        "path": "/vipmp/docs/subscription_management/update_subscription/",
-        "title": "Update Subscription",
-        "tags": ["subscription", "update", "PATCH", "PUT", "auto-renewal", "quantity", "modify"],
-    },
-
-    # Pricing & Notifications
-    {
-        "path": "/vipmp/docs/manage_pricing/",
-        "title": "Price Lists",
-        "tags": ["price list", "pricing", "pricelist", "POST", "currency", "offers", "3YC", "three-year commit"],
-    },
-    {
-        "path": "/vipmp/docs/notification_management/",
-        "title": "Notifications",
-        "tags": ["notification", "webhook", "event", "callback", "push"],
-    },
-
-    # Operational workflows
-    {
-        "path": "/vipmp/docs/customer_account/three_year_commit/",
-        "title": "Three-Year Commits (3YC)",
-        "tags": ["3YC", "three year commit", "commitment", "price lock"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/linked_membership/",
-        "title": "Linked Memberships",
-        "tags": ["linked membership", "membership", "link", "consolidation"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/high_growth/",
-        "title": "High Growth Offers — Overview",
-        "tags": ["high growth", "HGO", "offers", "growth offer"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/high_growth_scenarios/",
-        "title": "High Growth Offer Scenarios",
-        "tags": ["high growth", "HGO", "scenarios", "examples"],
-    },
-    {
-        "path": "/vipmp/docs/customer_account/high_growth_apis/",
-        "title": "Manage High Growth Offers through APIs",
-        "tags": ["high growth", "HGO", "API", "manage"],
-    },
-    {
-        "path": "/vipmp/docs/recommendations/",
-        "title": "Recommendations — Overview",
-        "tags": ["recommendations", "upsell", "cross-sell"],
-    },
-    {
-        "path": "/vipmp/docs/recommendations/apis/",
-        "title": "Manage Recommendations using APIs",
-        "tags": ["recommendations", "API", "manage"],
-    },
-    {
-        "path": "/vipmp/docs/recommendations/error_codes/",
-        "title": "Error Codes — Recommendations",
-        "tags": ["recommendations", "error codes", "errors"],
-    },
-    {
-        "path": "/vipmp/docs/flex_discounts/",
-        "title": "Flexible Discounts — Overview",
-        "tags": ["flexible discounts", "flex discount", "discount"],
-    },
-    {
-        "path": "/vipmp/docs/flex_discounts/apis/",
-        "title": "Manage Flexible Discounts using APIs",
-        "tags": ["flexible discounts", "API", "manage"],
-    },
-    {
-        "path": "/vipmp/docs/flex_discounts/error_codes/",
-        "title": "Error Codes — Flexible Discounts",
-        "tags": ["flexible discounts", "error codes", "errors"],
-    },
-    {
-        "path": "/vipmp/docs/mid_term/",
-        "title": "Mid-Term Upgrades — Overview",
-        "tags": ["mid-term", "upgrade", "mid term", "upsize"],
-    },
-    {
-        "path": "/vipmp/docs/mid_term/apis/",
-        "title": "Manage Mid-Term Upgrades through APIs",
-        "tags": ["mid-term", "upgrade", "API", "manage"],
-    },
-    {
-        "path": "/vipmp/docs/mid_term/error_codes/",
-        "title": "Error Codes — Mid-Term Upgrades",
-        "tags": ["mid-term", "upgrade", "error codes", "errors"],
-    },
-    {
-        "path": "/vipmp/docs/mid_term/faq/",
-        "title": "Mid-Term Upgrades FAQ",
-        "tags": ["mid-term", "upgrade", "FAQ", "questions"],
-    },
-
-    # Business processes
-    {
-        "path": "/vipmp/docs/reseller_change/",
-        "title": "Reseller Change Process — Overview",
-        "tags": ["reseller change", "transfer", "reseller transfer", "change reseller"],
-    },
-    {
-        "path": "/vipmp/docs/reseller_change/preview_transfer/",
-        "title": "Preview a Reseller Transfer",
-        "tags": ["reseller transfer", "preview", "GET"],
-    },
-    {
-        "path": "/vipmp/docs/reseller_change/commit_transfer/",
-        "title": "Commit a Reseller Transfer",
-        "tags": ["reseller transfer", "commit", "POST"],
-    },
-    {
-        "path": "/vipmp/docs/reseller_change/get_transfer/",
-        "title": "Get Reseller Transfer Details",
-        "tags": ["reseller transfer", "get", "GET", "details"],
-    },
-    {
-        "path": "/vipmp/docs/migration/",
-        "title": "Migrate to VIP Marketplace — Overview",
-        "tags": ["migration", "VIP", "transfer", "migrate", "classic VIP"],
-    },
-    {
-        "path": "/vipmp/docs/migration/preview_offers/",
-        "title": "Preview Offers (Migration)",
-        "tags": ["migration", "preview", "offers", "eligibility"],
-    },
-    {
-        "path": "/vipmp/docs/migration/transfer_subscription/",
-        "title": "Transfer Subscriptions (Migration)",
-        "tags": ["migration", "transfer", "subscription", "POST"],
-    },
-    {
-        "path": "/vipmp/docs/migration/get_transfer_details/",
-        "title": "Get Transfer Details (Migration)",
-        "tags": ["migration", "transfer", "get", "GET", "details"],
-    },
-    {
-        "path": "/vipmp/docs/migration/migrate_hvd/",
-        "title": "Migrate High Volume Discount (HVD) Customers",
-        "tags": ["migration", "HVD", "high volume discount", "VIP to VIP MP"],
-    },
-
-    # Large Government Agencies (LGA) — note: these use trailing-slashless paths in Adobe's docs
-    {
-        "path": "/vipmp/docs/lga/",
-        "title": "Large Government Agencies (LGA) — Overview",
-        "tags": ["LGA", "large government agency", "government", "GOV", "discount", "federal", "state", "linked membership", "US", "Canada"],
-    },
-    {
-        "path": "/vipmp/docs/lga/create/",
-        "title": "Create an LGA Customer",
-        "tags": ["LGA", "large government agency", "create", "POST", "customer", "FEDERAL", "STATE", "marketSubSegments", "linked membership", "enroll"],
-    },
-    {
-        "path": "/vipmp/docs/lga/migrate/",
-        "title": "Migrate LGA Customers from VIP to VIP Marketplace",
-        "tags": ["LGA", "large government agency", "migration", "transfer", "VIP", "migrate", "preview", "FRL"],
-    },
-    {
-        "path": "/vipmp/docs/lga/convert/",
-        "title": "Convert an Existing Government Customer to LGA",
-        "tags": ["LGA", "large government agency", "convert", "GOV", "government", "PENDING_UPGRADE", "anniversary date", "AD", "renewal", "PATCH"],
-    },
-    {
-        "path": "/vipmp/docs/lga/error-codes/",
-        "title": "Error Codes — LGA",
-        "tags": ["LGA", "large government agency", "error codes", "errors", "1117", "1118", "1147", "1163", "1164", "1167", "1168", "5117"],
-    },
-    {
-        "path": "/vipmp/docs/lga/references/",
-        "title": "LGA References",
-        "tags": ["LGA", "large government agency", "references"],
-    },
-
-    # References
-    {
-        "path": "/vipmp/docs/references/api_headers/",
-        "title": "API Request Headers",
-        "tags": ["headers", "request headers", "x-api-key", "authorization", "content-type"],
-    },
-    {
-        "path": "/vipmp/docs/references/idempotency/",
-        "title": "Idempotency — Correlation ID Header",
-        "tags": ["idempotency", "correlation id", "x-correlation-id", "duplicate requests"],
-    },
-    {
-        "path": "/vipmp/docs/references/status_codes/",
-        "title": "HTTP Status Codes",
-        "tags": ["HTTP status codes", "200", "400", "404", "500", "error", "response codes"],
-    },
-    {
-        "path": "/vipmp/docs/references/error_handling/",
-        "title": "Status Codes and Error Handling",
-        "tags": ["error handling", "error codes", "status codes", "errors", "troubleshooting"],
-    },
-    {
-        "path": "/vipmp/docs/references/supported_locales/",
-        "title": "Supported Countries and Locales",
-        "tags": ["countries", "locales", "currency", "region", "supported"],
-    },
-    {
-        "path": "/vipmp/docs/references/resources/",
-        "title": "Resources and Fields",
-        "tags": ["resources", "fields", "schema", "data model", "object reference"],
-    },
-    {
-        "path": "/vipmp/docs/references/validations/",
-        "title": "Validations and Regular Expressions",
-        "tags": ["validation", "regex", "regular expressions", "field validation", "format"],
-    },
-
-    # Support
-    {
-        "path": "/vipmp/docs/support/",
-        "title": "Support",
-        "tags": ["support", "help", "contact"],
-    },
-]
+# Last-path-segment → semantic tags. Consumed by
+# ``autositemap.merge_curated_tags`` to enrich live Adobe-sourced entries.
+#
+# When multiple pages share a last segment (e.g. ``.../flex-discounts/apis/``
+# and ``.../mid-term/apis/``) only one tag list can win per key; the order
+# below is the order that used to be encoded implicitly in the old SITEMAP
+# list (last-wins, preserved for behaviour parity).
+CURATED_TAGS: dict[str, list[str]] = {
+    "api-headers": ["authorization", "content-type", "headers", "request headers", "x-api-key"],
+    "apis": ["API", "manage", "mid-term", "upgrade"],
+    "authentication": ["access", "auth", "authentication", "credentials", "oauth", "token"],
+    "commit-transfer": ["POST", "commit", "reseller transfer"],
+    "convert": ["AD", "GOV", "LGA", "PATCH", "PENDING_UPGRADE", "anniversary date", "convert", "government", "large government agency", "renewal"],
+    "create": ["FEDERAL", "LGA", "POST", "STATE", "create", "customer", "enroll", "large government agency", "linked membership", "marketSubSegments"],
+    "create-customer-account": ["POST", "account", "create", "customer", "new customer"],
+    "create-deployment": ["POST", "create", "deployment"],
+    "create-order": ["POST", "create", "new order", "order", "purchase"],
+    "create-reseller-account": ["POST", "account", "create", "new reseller", "reseller"],
+    "create-subscription": ["POST", "create", "subscription"],
+    "customer-account": ["account", "customer", "overview"],
+    "deployment-management": ["deployment", "overview"],
+    "docs": ["customer", "distributor", "introduction", "order flow", "overview", "reseller", "workflow"],
+    "error-codes": ["1117", "1118", "1147", "1163", "1164", "1167", "1168", "5117", "LGA", "error codes", "errors", "large government agency"],
+    "error-handling": ["error codes", "error handling", "errors", "status codes", "troubleshooting"],
+    "faq": ["FAQ", "mid-term", "questions", "upgrade"],
+    "flex-discounts": ["discount", "flex discount", "flexible discounts"],
+    "get-customer-account": ["GET", "account details", "customer", "get", "retrieve"],
+    "get-customer-list": ["GET", "all customers", "customer", "list", "pagination"],
+    "get-deployment": ["GET", "deployment", "details", "get"],
+    "get-details": ["GET", "details", "get", "single", "subscription"],
+    "get-details-for-customers": ["GET", "all", "customer subscriptions", "list", "subscription"],
+    "get-licenses": ["GET", "customer licenses", "licenses", "partner order", "pending"],
+    "get-order": ["GET", "details", "get", "order", "retrieve"],
+    "get-reseller-account": ["GET", "account details", "get", "reseller", "retrieve"],
+    "get-reseller-list": ["GET", "all resellers", "list", "pagination", "reseller"],
+    "get-transfer": ["GET", "details", "get", "reseller transfer"],
+    "get-transfer-details": ["GET", "details", "get", "migration", "transfer"],
+    "health-check": ["connectivity", "health check", "ping", "status"],
+    "high-growth": ["HGO", "growth offer", "high growth", "offers"],
+    "high-growth-apis": ["API", "HGO", "high growth", "manage"],
+    "high-growth-scenarios": ["HGO", "examples", "high growth", "scenarios"],
+    "idempotency": ["correlation id", "duplicate requests", "idempotency", "x-correlation-id"],
+    "lga": ["Canada", "GOV", "LGA", "US", "discount", "federal", "government", "large government agency", "linked membership", "state"],
+    "linked-membership": ["consolidation", "link", "linked membership", "membership"],
+    "manage-pricing": ["3YC", "POST", "currency", "offers", "price list", "pricelist", "pricing", "three-year commit"],
+    "market-segments": ["commercial", "education", "government", "market segments", "segment"],
+    "mid-term": ["mid term", "mid-term", "upgrade", "upsize"],
+    "migrate": ["FRL", "LGA", "VIP", "large government agency", "migrate", "migration", "preview", "transfer"],
+    "migrate-hvd": ["HVD", "VIP to VIP MP", "high volume discount", "migration"],
+    "migration": ["VIP", "classic VIP", "migrate", "migration", "transfer"],
+    "notification-management": ["callback", "event", "notification", "push", "webhook"],
+    "oauth-credentials": ["authentication", "client id", "client secret", "credentials", "oauth", "token"],
+    "order-management": ["cancel", "order", "overview"],
+    "order-scenarios": ["examples", "new", "order", "renewal", "return", "scenarios", "use cases"],
+    "preview-offers": ["eligibility", "migration", "offers", "preview"],
+    "preview-transfer": ["GET", "preview", "reseller transfer"],
+    "recommendations": ["cross-sell", "recommendations", "upsell"],
+    "references": ["LGA", "large government agency", "references"],
+    "release-notes": ["changelog", "recent", "release notes", "updates"],
+    "reseller-account": ["account", "distributor", "partner", "reseller"],
+    "reseller-change": ["change reseller", "reseller change", "reseller transfer", "transfer"],
+    "resources": ["data model", "fields", "object reference", "resources", "schema"],
+    "status-codes": ["200", "400", "404", "500", "HTTP status codes", "error", "response codes"],
+    "subscription-management": ["auto-renewal", "overview", "subscription"],
+    "support": ["contact", "help", "support"],
+    "supported-locales": ["countries", "currency", "locales", "region", "supported"],
+    "three-year-commit": ["3YC", "commitment", "price lock", "three year commit"],
+    "transfer-subscription": ["POST", "migration", "subscription", "transfer"],
+    "upcoming-releases": ["future", "release notes", "roadmap", "upcoming"],
+    "update-customer-account": ["PATCH", "PUT", "customer", "modify", "update"],
+    "update-deployment": ["PATCH", "PUT", "deployment", "modify", "update"],
+    "update-order": ["PATCH", "PUT", "cancel", "modify", "order", "update"],
+    "update-reseller-account": ["PATCH", "PUT", "modify", "reseller", "update"],
+    "update-subscription": ["PATCH", "PUT", "auto-renewal", "modify", "quantity", "subscription", "update"],
+    "validations": ["field validation", "format", "regex", "regular expressions", "validation"],
+}
 
 
 def normalize_path(path: str) -> str:
@@ -424,17 +123,3 @@ def normalize_path(path: str) -> str:
     if len(path) > 1 and path.endswith("/"):
         path = path.rstrip("/")
     return path
-
-
-def known_paths() -> set[str]:
-    """Normalized set of known doc paths for membership checks."""
-    return {normalize_path(e["path"]) for e in SITEMAP}
-
-
-def find_by_path(path: str) -> SitemapEntry | None:
-    """Look up a sitemap entry by path (normalized)."""
-    normalized = normalize_path(path)
-    for entry in SITEMAP:
-        if normalize_path(entry["path"]) == normalized:
-            return entry
-    return None

--- a/tests/test_autositemap.py
+++ b/tests/test_autositemap.py
@@ -1,0 +1,138 @@
+"""
+Tests for the sitemap tier resolution introduced in 0.7.2 (GitHub #6).
+
+Covers ``get_active_sitemap``'s priority chain (user cache → package-shipped
+→ empty) and ``merge_curated_tags``'s interaction with ``CURATED_TAGS``.
+The network-heavy ``build_sitemap`` path stays out of scope here — it's
+exercised end-to-end by the CI refresh workflow.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from vipmp_docs_mcp import autositemap
+from vipmp_docs_mcp.autositemap import (
+    SITEMAP_SCHEMA_VERSION,
+    get_active_sitemap,
+    merge_curated_tags,
+)
+
+
+def _payload(entries: list[dict]) -> str:
+    return json.dumps(
+        {
+            "schema_version": SITEMAP_SCHEMA_VERSION,
+            "generated_at": time.time(),
+            "entries": entries,
+        }
+    )
+
+
+class TestGetActiveSitemapTierOrder:
+    @pytest.fixture(autouse=True)
+    def isolate_paths(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        """Redirect both tier paths to tmp_path so tests never touch
+        the real user cache or the shipped package fallback."""
+        self.user_path = tmp_path / "user-sitemap.json"
+        self.pkg_path = tmp_path / "pkg-sitemap.json"
+        monkeypatch.setattr(autositemap, "SITEMAP_JSON_PATH", self.user_path)
+        monkeypatch.setattr(autositemap, "PACKAGE_SITEMAP_PATH", self.pkg_path)
+
+    def test_user_cache_wins_over_package(self):
+        self.user_path.write_text(
+            _payload([{"path": "/vipmp/docs/u", "title": "User", "tags": []}])
+        )
+        self.pkg_path.write_text(
+            _payload([{"path": "/vipmp/docs/p", "title": "Package", "tags": []}])
+        )
+        active = get_active_sitemap()
+        assert len(active) == 1
+        assert active[0]["title"] == "User"
+
+    def test_package_fallback_when_user_missing(self):
+        self.pkg_path.write_text(
+            _payload([{"path": "/vipmp/docs/p", "title": "Package", "tags": []}])
+        )
+        active = get_active_sitemap()
+        assert len(active) == 1
+        assert active[0]["title"] == "Package"
+
+    def test_empty_when_both_missing(self):
+        """Last resort — no hand-curated list to fall back to anymore
+        (retired in 0.7.2). Callers must handle empty gracefully."""
+        active = get_active_sitemap()
+        assert active == []
+
+    def test_package_fallback_when_user_is_corrupt(self):
+        """A broken user cache shouldn't mask the package fallback."""
+        self.user_path.write_text("not json {{{")
+        self.pkg_path.write_text(
+            _payload([{"path": "/vipmp/docs/p", "title": "Package", "tags": []}])
+        )
+        active = get_active_sitemap()
+        assert len(active) == 1
+        assert active[0]["title"] == "Package"
+
+    def test_schema_mismatch_falls_through(self):
+        """A user cache written under an old schema version is ignored."""
+        self.user_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": SITEMAP_SCHEMA_VERSION + 99,
+                    "generated_at": time.time(),
+                    "entries": [{"path": "/vipmp/docs/u", "title": "Old", "tags": []}],
+                }
+            )
+        )
+        self.pkg_path.write_text(
+            _payload([{"path": "/vipmp/docs/p", "title": "Package", "tags": []}])
+        )
+        active = get_active_sitemap()
+        assert active[0]["title"] == "Package"
+
+
+class TestMergeCuratedTags:
+    def test_attaches_tags_for_known_last_segment(self):
+        entries = [
+            {
+                "path": "/vipmp/docs/authentication",
+                "title": "Authentication",
+                "tags": ["existing"],
+            }
+        ]
+        out = merge_curated_tags(entries)
+        # `authentication` is a known key in CURATED_TAGS.
+        assert "existing" in out[0]["tags"]
+        assert "oauth" in out[0]["tags"]
+
+    def test_unknown_segment_leaves_tags_alone(self):
+        entries = [
+            {
+                "path": "/vipmp/docs/some-never-heard-of-thing",
+                "title": "Whatever",
+                "tags": ["only-this"],
+            }
+        ]
+        out = merge_curated_tags(entries)
+        assert out[0]["tags"] == ["only-this"]
+
+    def test_preserves_uniqueness_and_sorts(self):
+        """Merge must dedup tags (entry + curated can overlap) and return
+        them in a stable sorted order."""
+        entries = [
+            {
+                "path": "/vipmp/docs/authentication",
+                "title": "Authentication",
+                "tags": ["oauth", "zzz-last"],  # "oauth" is also in CURATED_TAGS
+            }
+        ]
+        out = merge_curated_tags(entries)
+        tags = out[0]["tags"]
+        assert tags == sorted(tags)
+        assert tags.count("oauth") == 1  # no duplicates
+        assert "zzz-last" in tags

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,8 +1,8 @@
-"""Tests for path normalization and sitemap lookup helpers."""
+"""Tests for normalize_path and the CURATED_TAGS metadata."""
 
 from __future__ import annotations
 
-from vipmp_docs_mcp.sitemap import find_by_path, known_paths, normalize_path
+from vipmp_docs_mcp.sitemap import CURATED_TAGS, normalize_path
 
 
 class TestNormalizePath:
@@ -23,26 +23,25 @@ class TestNormalizePath:
         assert normalize_path("x") == "/x"
 
 
-class TestKnownPaths:
-    def test_all_paths_normalized(self):
-        # Every returned path should be in normalized form (leading slash, no trailing).
-        for p in known_paths():
-            assert p.startswith("/")
-            assert p == "/" or not p.endswith("/")
+class TestCuratedTags:
+    def test_has_entries(self):
+        """Regression guard — the dict shouldn't silently empty out."""
+        assert len(CURATED_TAGS) > 50
 
+    def test_keys_are_hyphenated_slug_form(self):
+        """Every key is a bare lowercase slug (hyphens, no underscores,
+        no slashes, no whitespace). ``autositemap.merge_curated_tags``
+        looks up by the last path segment of a live Adobe entry, so any
+        key that doesn't match that shape is dead weight."""
+        for key in CURATED_TAGS:
+            assert key == key.lower()
+            assert "_" not in key
+            assert "/" not in key
+            assert " " not in key
 
-class TestFindByPath:
-    def test_finds_existing(self):
-        entry = find_by_path("/vipmp/docs/lga/")
-        assert entry is not None
-        assert "LGA" in entry["title"] or "Large Government" in entry["title"]
-
-    def test_works_regardless_of_slash(self):
-        with_slash = find_by_path("/vipmp/docs/lga/")
-        without_slash = find_by_path("/vipmp/docs/lga")
-        assert with_slash is not None
-        assert without_slash is not None
-        assert with_slash["path"] == without_slash["path"]
-
-    def test_returns_none_for_unknown(self):
-        assert find_by_path("/vipmp/docs/definitely-not-a-page/") is None
+    def test_values_are_non_empty_lists(self):
+        for key, tags in CURATED_TAGS.items():
+            assert isinstance(tags, list), f"{key!r} tags isn't a list"
+            assert tags, f"{key!r} has no tags — delete the entry instead"
+            for tag in tags:
+                assert isinstance(tag, str) and tag


### PR DESCRIPTION
Fixes #6.

## Summary

Retire the hand-curated path list in \`sitemap.py\` (46 of 72 entries were using Adobe's old underscore-separated slugs) and replace it with a CI-generated \`data/sitemap.json\` shipped in the wheel. Fresh installs now land on a working, current sitemap with zero network on first run.

## What changed

**Retired:**
- \`sitemap.SITEMAP\` (the 440-line hand-curated list).
- \`sitemap.known_paths\` and \`sitemap.find_by_path\` — their only caller was the hand-curated fallback in \`server.py\`, which is also retired.
- \`autositemap._build_curated_tag_index\` — folded into \`merge_curated_tags\` now that the source is a dict.

**Added:**
- \`src/vipmp_docs_mcp/data/sitemap.json\` — 86 entries, hyphen paths, curated tags merged. Shipped with the wheel. Regenerated daily by \`refresh-index.yml\`.
- \`sitemap.CURATED_TAGS\` — dict of \`{last-path-segment: [tags]}\` carrying the semantic tags we actually contribute on top of Adobe's data (3YC, LGA, HGO, x-correlation-id, etc.). 67 entries.
- \`tests/test_autositemap.py\` — covers the new tier chain (user-cache wins, package fallback, corrupt-cache fallthrough, schema mismatch) and \`merge_curated_tags\` behaviour.

**Changed:**
- \`get_active_sitemap\` tier chain: **user-cache → package-shipped → empty** (old: user-cache → hand-curated). The middle tier is new — zero-network first run.
- \`refresh-index.yml\` daily workflow now regenerates \`data/sitemap.json\` alongside \`data/index.json\` and ships both in the same bot PR. Diff detection ignores the \`generated_at\` timestamp on the sitemap the same way it ignores \`built_at\` on the index.
- \`server._find_by_path\` no longer has anything to fall back to; simplified to return \`None\` when the active sitemap misses. Callers already tolerated \`None\`.

## Why this matters

v0.7.1 fixed the \`rebuild_vipmp_index\` crash and the CI-ships-broken-index problem by having \`build_index\` refresh the sitemap from Adobe before fetching pages. But fresh installs before the user ran \`rebuild_vipmp_index\` or \`refresh_vipmp_sitemap\` would still hit the stale hand-curated list for search/listing calls — meaning doc links pointed at 404-ing URLs until the user knew to explicitly refresh. This PR closes that remaining hole.

## Risk assessment

**Low.** The only behaviour change users could notice is search results looking different — because they're now against Adobe's current URLs rather than stale ones. The same tags still attach to the same topics (the tag-merge key was already hyphen-normalised).

**Backward-compat:** persisted \`~/.cache/.../sitemap.json\` files from previous versions continue to work; same schema version (1).

## Test plan

- [x] All 168 tests pass (8 new: 5 tier-chain + 3 tag-merge behaviour)
- [x] \`ruff check src/ tests/\` clean
- [x] \`mcpb validate manifest.json\` clean; \`mcpb pack\` includes both \`data/sitemap.json\` and \`data/index.json\`
- [x] Version parity: \`pyproject.toml\`, \`__init__.py\`, \`manifest.json\` all at 0.7.2
- [x] Smoke test: fresh Python process imports the package, \`get_active_sitemap\` returns 86 entries loaded from the shipped fallback
- [ ] Post-merge: tag \`v0.7.2\`, workflows publish to PyPI + attach MCPB to GitHub Release
- [ ] Post-release: next daily refresh-index run verifies the workflow changes work in practice (refreshes both files, opens one PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)