### PR TITLE
chore(security): address external code-review findings

### DIFF
--- a/.github/workflows/refresh-index.yml
+++ b/.github/workflows/refresh-index.yml
@@ -100,6 +100,65 @@ jobs:
           )
           PY
 
+      - name: Validate structural invariants
+        # Fail-loud guard against poisoning / parser regressions before the
+        # PR ever opens. Same floors that `remote_index._check_invariants`
+        # enforces at fetch time, plus a parse-error fraction check that
+        # mirrors `STALE_INDEX_FAILURE_FRACTION` in server.py. If any
+        # invariant fails the workflow fails and no PR is opened — the
+        # daily refresh just pauses until a human investigates.
+        run: |
+          python - <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          from vipmp_docs_mcp.index import INDEX_SCHEMA_VERSION
+          from vipmp_docs_mcp.remote_index import (
+              MIN_ENDPOINTS,
+              MIN_ERROR_CODES,
+              MIN_SCHEMAS,
+              _check_invariants,
+              IndexInvariantError,
+          )
+          from vipmp_docs_mcp.server import STALE_INDEX_FAILURE_FRACTION
+
+          path = Path("src/vipmp_docs_mcp/data/index.json")
+          data = json.loads(path.read_text(encoding="utf-8"))
+
+          # Structural floors (schema version, endpoint/error-code/schema counts).
+          try:
+              _check_invariants(data)
+          except IndexInvariantError as exc:
+              print(f"::error::Index failed structural invariants: {exc}")
+              sys.exit(1)
+
+          # Parse-error fraction sanity check.
+          sitemap_size = int(data.get("source_sitemap_size") or 0)
+          parse_errors = data.get("parse_errors") or []
+          if sitemap_size > 0:
+              fraction = len(parse_errors) / sitemap_size
+              if fraction >= STALE_INDEX_FAILURE_FRACTION:
+                  print(
+                      f"::error::parse-error fraction {fraction:.0%} >= "
+                      f"threshold {STALE_INDEX_FAILURE_FRACTION:.0%} "
+                      f"({len(parse_errors)}/{sitemap_size}); aborting refresh"
+                  )
+                  sys.exit(1)
+
+          print(
+              f"OK: schema_version={data.get('schema_version')} "
+              f"(want {INDEX_SCHEMA_VERSION}), "
+              f"endpoints={len(data.get('endpoints', []))} "
+              f"(min {MIN_ENDPOINTS}), "
+              f"error_codes={len(data.get('error_codes', []))} "
+              f"(min {MIN_ERROR_CODES}), "
+              f"schemas={len(data.get('schemas', []))} "
+              f"(min {MIN_SCHEMAS}), "
+              f"parse_errors={len(parse_errors)}/{sitemap_size}"
+          )
+          PY
+
       - name: Check if index or sitemap changed
         id: diff
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security / hardening (response to external code review)
+- **Curl snippets now use a heredoc body** (`codegen.py`). The previous
+  `-d '{...}'` form silently broke whenever a JSON string value
+  contained an apostrophe. The new `--data-binary @- <<'JSON'` form
+  passes the body verbatim, so any byte (including `'`, `` ` ``, `$`)
+  is safe.
+- **Async fetcher now retries transient failures** (`fetcher.py`). The
+  parallel fetch path used by `warm_vipmp_cache` and `build_index`
+  previously surfaced 503/429/timeouts as immediate per-page failures;
+  it now uses the same tenacity policy as the sync path (3 attempts,
+  exponential backoff, retry only on transient transport/5xx/429).
+- **Shared `run_async` helper** (`fetcher.py`). Both `build_index` and
+  `warm_vipmp_cache` now dispatch their parallel fetch through one
+  helper that probes for a running event loop and isolates work in a
+  worker thread when needed. Removes the bare `asyncio.run` in
+  `warm_vipmp_cache` that would have raised under any future MCP
+  runtime that drives sync tools inside the loop thread.
+- **Public cache write APIs** (`cache.py`). New `DocsCache.put` and
+  `DocsCache.put_many` replace the private `_entries`/`_load`/`_save`
+  reach-around in `warm_vipmp_cache`. `put_many` issues one atomic
+  write for the whole batch instead of fsync-per-page.
+- **Remote-index structural invariants** (`remote_index.py`). Before
+  overwriting the cached copy, the GitHub-refreshed tier now checks
+  `schema_version` matches the expected value and that
+  `endpoints`/`error_codes`/`schemas` exceed conservative floors (10 /
+  20 / 5). Mass-deletion-style poisoning of `main` is rejected and the
+  existing cached/baseline copy is preserved. Defense-in-depth, not a
+  substitute for signing.
+- **Refresh workflow validates the rebuilt index**
+  (`refresh-index.yml`). A new step runs the same invariants plus a
+  parse-error fraction check (≥25% aborts, mirroring
+  `STALE_INDEX_FAILURE_FRACTION` in `server.py`) before opening the
+  auto-merged PR. A regression now fails the workflow loud rather than
+  landing on `main` and propagating to downstream installs within 12h
+  via the github-remote tier.
+
 ## [0.8.0] — 2026-04-21
 
 ### Added

--- a/src/vipmp_docs_mcp/cache.py
+++ b/src/vipmp_docs_mcp/cache.py
@@ -126,6 +126,34 @@ class DocsCache:
         self._load()
         return self._entries.get(normalize_path(path))
 
+    def put(self, path: str, content: str, *, etag: str | None = None) -> None:
+        """
+        Store cleaned content for a path and atomically persist to disk.
+
+        Public counterpart to `get_or_fetch`'s internal write — used by
+        callers that already have the cleaned content in hand and want
+        to seed the cache without reaching into private state.
+        """
+        self._load()
+        self._entries[normalize_path(path)] = CacheEntry(
+            content=content, etag=etag, fetched_at=time.time()
+        )
+        self._save()
+
+    def put_many(self, entries: dict[str, str]) -> None:
+        """
+        Store many `{path: cleaned_content}` pairs and persist with one
+        atomic write at the end. Used by the parallel warmup so we
+        don't fsync once per page.
+        """
+        self._load()
+        now = time.time()
+        for path, content in entries.items():
+            self._entries[normalize_path(path)] = CacheEntry(
+                content=content, etag=None, fetched_at=now
+            )
+        self._save()
+
     def get_or_fetch(self, path: str) -> str:
         """
         Return cleaned content for a path. If cached and fresh, serve from cache.

--- a/src/vipmp_docs_mcp/codegen.py
+++ b/src/vipmp_docs_mcp/codegen.py
@@ -117,9 +117,14 @@ def _emit_curl(method: str, url: str, body: dict | None) -> str:
     ]
     if body is not None and method in {"POST", "PATCH", "PUT"}:
         body_str = json.dumps(body, indent=2)
-        # Continue the last header line with backslash.
+        # Heredoc with single-quoted marker passes the body verbatim — no
+        # quoting/escaping needed for embedded apostrophes, backticks, or
+        # `$` sequences. Beats `-d '...'` which breaks on any single quote
+        # in a string value.
         lines[-1] = lines[-1] + " \\"
-        lines.append(f"  -d '{body_str}'")
+        lines.append("  --data-binary @- <<'JSON'")
+        lines.append(body_str)
+        lines.append("JSON")
     return "\n".join(lines)
 
 

--- a/src/vipmp_docs_mcp/fetcher.py
+++ b/src/vipmp_docs_mcp/fetcher.py
@@ -229,6 +229,25 @@ DEFAULT_CONCURRENCY = 5
 """Be polite to Adobe's CDN — 5 concurrent requests is plenty for our use case."""
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5, min=0.5, max=4.0),
+    retry=retry_if_exception(_is_retryable),
+    reraise=True,
+)
+async def _async_fetch_with_retries(
+    client: httpx.AsyncClient, url: str, headers: dict[str, str]
+) -> httpx.Response:
+    """Async retry-wrapped fetch. Mirrors `_fetch_with_retries` policy."""
+    log.debug("async-fetching %s", url)
+    response = await client.get(url, headers=headers)
+    if response.status_code in _RETRYABLE_STATUS:
+        # Trigger tenacity retry. raise_for_status raises HTTPStatusError,
+        # which `_is_retryable` catches for the retryable status set.
+        response.raise_for_status()
+    return response
+
+
 async def _async_fetch_one(
     client: httpx.AsyncClient,
     path: str,
@@ -237,16 +256,27 @@ async def _async_fetch_one(
 ) -> str:
     """
     Async equivalent of fetch_page_html for one path. Includes the same
-    trailing-slash fallback semantics. Raises FetchError on failure.
+    trailing-slash fallback semantics and the same retry/backoff policy
+    as the sync fetcher. Raises FetchError on failure.
     """
     last_err: Exception | None = None
     for candidate in _trailing_slash_variants(path):
         url = BASE_URL + candidate
         try:
-            response = await client.get(url, headers=_default_headers())
+            response = await _async_fetch_with_retries(
+                client, url, _default_headers()
+            )
         except (httpx.TransportError, httpx.TimeoutException) as exc:
             log.warning("network error for %s: %s", candidate, exc)
             raise FetchError(f"network error fetching {path}: {exc}") from exc
+        except httpx.HTTPStatusError as exc:
+            log.warning("HTTP %s for %s after retries", exc.response.status_code, candidate)
+            raise FetchError(
+                f"HTTP {exc.response.status_code} {exc.response.reason_phrase} for {path}"
+            ) from exc
+        except RetryError as exc:
+            log.warning("retries exhausted for %s", candidate)
+            raise FetchError(f"retries exhausted fetching {path}") from exc
 
         if response.status_code == 404:
             last_err = FetchError(f"HTTP 404 Not Found for {candidate}")
@@ -330,3 +360,32 @@ async def async_fetch_many(
     succeeded = sum(1 for v in results.values() if isinstance(v, str))
     log.info("async_fetch_many: %d/%d succeeded", succeeded, total)
     return results
+
+
+def run_async(coro_factory):
+    """
+    Run an async coroutine from a sync context, even if a loop is active.
+
+    `asyncio.run()` raises "cannot be called from a running event loop"
+    when invoked under one — which can happen if a future MCP runtime
+    drives sync tool bodies inside the loop thread. To stay safe in
+    both shapes:
+
+      - if no loop is running, dispatch directly via `asyncio.run`;
+      - if a loop is running, isolate the work in a short-lived worker
+        thread with its own fresh loop.
+
+    `coro_factory` is a zero-arg callable that returns the coroutine.
+    The deferred construction matters: building the coroutine under one
+    loop and awaiting it under another raises "attached to a different
+    loop". The factory pattern defers construction to the worker.
+    """
+    import concurrent.futures
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro_factory())
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(lambda: asyncio.run(coro_factory())).result()

--- a/src/vipmp_docs_mcp/index.py
+++ b/src/vipmp_docs_mcp/index.py
@@ -135,14 +135,11 @@ def build_index() -> IndexSnapshot:
     ~20s cold (was ~60s serial).
 
     Callable from both synchronous contexts (CI scripts, REPL) and from
-    inside a running event loop (MCP tool handlers). See the fetch call
-    below for the asyncio.run nesting guard.
+    inside a running event loop (MCP tool handlers); the parallel fetch
+    is dispatched via `fetcher.run_async`, which handles either shape.
     """
-    import asyncio
-    import concurrent.futures
-
     from .autositemap import build_sitemap, save_sitemap
-    from .fetcher import async_fetch_many
+    from .fetcher import async_fetch_many, run_async
 
     # Refresh the sitemap from Adobe before doing anything else. The
     # hand-curated fallback in sitemap.py still uses underscore-separated
@@ -169,22 +166,7 @@ def build_index() -> IndexSnapshot:
     title_for = {entry["path"]: entry["title"] for entry in sitemap}
 
     log.info("build_index: fetching %d pages in parallel", len(paths))
-    # Run the parallel fetch whether we're in a sync context (CI, scripts)
-    # or already inside an event loop (MCP tool handler). `asyncio.run()`
-    # can't nest — it raises "cannot be called from a running event loop"
-    # — so when a loop is active we isolate the coroutine in a short-lived
-    # thread with its own fresh loop. The lambda is deliberate: it defers
-    # coroutine construction to the worker thread so no async state is
-    # built under the outer loop's context.
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        fetch_results = asyncio.run(async_fetch_many(paths, concurrency=5))
-    else:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            fetch_results = pool.submit(
-                lambda: asyncio.run(async_fetch_many(paths, concurrency=5))
-            ).result()
+    fetch_results = run_async(lambda: async_fetch_many(paths, concurrency=5))
 
     for path in paths:
         result = fetch_results.get(path)

--- a/src/vipmp_docs_mcp/remote_index.py
+++ b/src/vipmp_docs_mcp/remote_index.py
@@ -55,6 +55,53 @@ DISABLE_ENV = "VIPMP_DISABLE_REMOTE_INDEX"
 
 _FETCH_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
 
+# Structural invariants the fetched index must satisfy before we trust it
+# enough to overwrite the cached copy. The github-remote tier reads from
+# mutable `main`, so a poisoned or accidentally-broken index could otherwise
+# silently propagate to every downstream install within the 12h TTL. These
+# floors are well below the live counts (21 endpoints / 65 error codes / 18
+# schemas at the time of writing) but high enough to catch the realistic
+# failure mode: a refresh PR that mass-deletes content.
+#
+# This is defense-in-depth, not a substitute for signing. Targeted additions
+# of fake endpoints can't be detected without an authenticated source.
+MIN_ENDPOINTS = 10
+MIN_ERROR_CODES = 20
+MIN_SCHEMAS = 5
+
+
+class IndexInvariantError(ValueError):
+    """The fetched index didn't pass structural sanity checks."""
+
+
+def _check_invariants(data: dict) -> None:
+    """
+    Raise IndexInvariantError if the parsed JSON looks structurally wrong.
+
+    Imported lazily inside the function to avoid a circular import — the
+    expected schema_version lives in `index.py`.
+    """
+    from .index import INDEX_SCHEMA_VERSION
+
+    if data.get("schema_version") != INDEX_SCHEMA_VERSION:
+        raise IndexInvariantError(
+            f"schema_version is {data.get('schema_version')!r}, "
+            f"expected {INDEX_SCHEMA_VERSION}"
+        )
+
+    for key, floor in (
+        ("endpoints", MIN_ENDPOINTS),
+        ("error_codes", MIN_ERROR_CODES),
+        ("schemas", MIN_SCHEMAS),
+    ):
+        value = data.get(key)
+        if not isinstance(value, list):
+            raise IndexInvariantError(f"{key!r} is not a list")
+        if len(value) < floor:
+            raise IndexInvariantError(
+                f"{key!r} has {len(value)} entries, minimum {floor}"
+            )
+
 
 def _is_disabled() -> bool:
     return os.environ.get(DISABLE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
@@ -172,12 +219,22 @@ def ensure_fresh() -> Path | None:
 
     body = response.content
     try:
-        # Sanity-parse: don't write garbage to disk. Schema validation
-        # happens when index.py tries to load the file — rejecting it
-        # there falls through to the baseline tier, which is correct.
-        json.loads(body)
+        parsed = json.loads(body)
     except json.JSONDecodeError as exc:
         log.warning("remote index response is not valid JSON (%s); ignoring", exc)
+        return index_path if have_cached else None
+
+    # Defense-in-depth: reject indexes that fail structural sanity checks
+    # before we overwrite the cached copy. This catches mass-deletion-style
+    # poisoning of `main` (PAT compromise, accidental bad merge) without
+    # blocking the legitimate daily refresh path.
+    try:
+        _check_invariants(parsed)
+    except IndexInvariantError as exc:
+        log.warning(
+            "remote index failed structural invariants (%s); using cached copy if any",
+            exc,
+        )
         return index_path if have_cached else None
 
     _write_atomic(body, index_path)

--- a/src/vipmp_docs_mcp/server.py
+++ b/src/vipmp_docs_mcp/server.py
@@ -271,43 +271,38 @@ def warm_vipmp_cache() -> str:
 
     Returns a summary of fetches, cache hits, and any errors.
     """
-    import asyncio
-
-    from .fetcher import async_fetch_many
+    from .fetcher import async_fetch_many, run_async
     from .html_cleaner import extract_text
 
     cache = get_cache()
     paths = [entry["path"] for entry in _get_sitemap()]
     before_snapshot = {p: cache.get(p) for p in paths}
 
-    # Parallel fetch — ~6s for 86 pages vs ~30s serial.
-    results = asyncio.run(async_fetch_many(paths, concurrency=5))
+    # Parallel fetch — ~6s for 86 pages vs ~30s serial. `run_async`
+    # tolerates being called from inside an active event loop, so this
+    # works under any MCP runtime shape.
+    results = run_async(lambda: async_fetch_many(paths, concurrency=5))
 
     fetched = 0
     revalidated = 0
     errors: list[tuple[str, str]] = []
+    to_persist: dict[str, str] = {}
 
     for path, result in results.items():
         if isinstance(result, FetchError):
             errors.append((path, str(result)))
             log.warning("warm_cache failed for %s: %s", path, result)
             continue
-        # Successful fetch — clean and persist.
         new_content = extract_text(result)
         before = before_snapshot.get(path)
         if before is None or before.content != new_content:
             fetched += 1
         else:
             revalidated += 1
-        # Reuse cache.get_or_fetch's cleaning + storage path by writing directly.
-        import time as _time
+        to_persist[path] = new_content
 
-        from .cache import CacheEntry
-        cache._load()
-        cache._entries[path] = CacheEntry(
-            content=new_content, etag=None, fetched_at=_time.time()
-        )
-    cache._save()
+    if to_persist:
+        cache.put_many(to_persist)
 
     lines = [
         "# Cache warmup complete",

--- a/tests/test_async_fetcher.py
+++ b/tests/test_async_fetcher.py
@@ -85,3 +85,15 @@ class TestAsyncFetchMany:
         )
         results = asyncio.run(async_fetch_many(["/login"]))
         assert isinstance(results["/login"], FetchError)
+
+    def test_transient_5xx_is_retried(self, httpx_mock: HTTPXMock):
+        # First two responses 503, then 200 — the async path should retry
+        # under the same policy as the sync path and end up succeeding.
+        url = f"{BASE_URL}/flaky"
+        httpx_mock.add_response(url=url, status_code=503)
+        httpx_mock.add_response(url=url, status_code=503)
+        httpx_mock.add_response(url=url, html=REAL_PAGE_HTML)
+
+        results = asyncio.run(async_fetch_many(["/flaky"]))
+        assert isinstance(results["/flaky"], str)
+        assert "vipmp content" in results["/flaky"]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -77,3 +77,23 @@ class TestDocsCache:
         )
         cache = DocsCache(path=tmp_cache_path)
         assert cache.get("/x") is None
+
+    def test_put_persists_single(self, tmp_cache_path: Path):
+        cache = DocsCache(path=tmp_cache_path)
+        cache.put("/a", "body-a", etag='W/"1"')
+
+        cache2 = DocsCache(path=tmp_cache_path)
+        entry = cache2.get("/a")
+        assert entry is not None
+        assert entry.content == "body-a"
+        assert entry.etag == 'W/"1"'
+
+    def test_put_many_persists_with_one_save(self, tmp_cache_path: Path):
+        cache = DocsCache(path=tmp_cache_path)
+        cache.put_many({"/a": "A", "/b": "B", "/c": "C"})
+
+        cache2 = DocsCache(path=tmp_cache_path)
+        for path, expected in [("/a", "A"), ("/b", "B"), ("/c", "C")]:
+            entry = cache2.get(path)
+            assert entry is not None
+            assert entry.content == expected

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -111,6 +111,21 @@ class TestGenerateSnippet:
         assert "X-Api-Key" in result.code
         assert "Content-Type: application/json" in result.code
 
+    def test_curl_body_with_apostrophe_is_safe(self, patched_index):
+        # Single quotes in JSON string values used to break the snippet
+        # because the body was wrapped in `-d '...'`. The heredoc form
+        # passes the bytes verbatim.
+        body = '{"name": "O\'Brien"}'
+        result = generate_snippet(
+            "POST /v3/customers", body_json=body, language="curl"
+        )
+        assert isinstance(result, CodeSnippet)
+        assert "<<'JSON'" in result.code
+        assert "\nJSON" in result.code
+        assert "O'Brien" in result.code
+        # The fragile `-d '...'` form must not appear.
+        assert " -d '" not in result.code
+
     def test_powershell_includes_invoke(self, patched_index):
         result = generate_snippet("POST /v3/customers", language="powershell")
         assert isinstance(result, CodeSnippet)

--- a/tests/test_remote_index.py
+++ b/tests/test_remote_index.py
@@ -32,7 +32,26 @@ def isolate_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     return idx, meta
 
 
-SAMPLE_BODY = json.dumps({"schema_version": 4, "endpoints": []}).encode()
+def _valid_index_body() -> bytes:
+    """Build a payload that satisfies the structural-invariant floors."""
+    from vipmp_docs_mcp.index import INDEX_SCHEMA_VERSION
+    from vipmp_docs_mcp.remote_index import (
+        MIN_ENDPOINTS,
+        MIN_ERROR_CODES,
+        MIN_SCHEMAS,
+    )
+
+    return json.dumps(
+        {
+            "schema_version": INDEX_SCHEMA_VERSION,
+            "endpoints": [{} for _ in range(MIN_ENDPOINTS)],
+            "error_codes": [{} for _ in range(MIN_ERROR_CODES)],
+            "schemas": [{} for _ in range(MIN_SCHEMAS)],
+        }
+    ).encode()
+
+
+SAMPLE_BODY = _valid_index_body()
 
 
 class TestDisabled:
@@ -85,6 +104,66 @@ class TestFreshFetch:
             content=b"<html>rate limited</html>",
         )
         # No cached copy, so we return None rather than writing garbage.
+        assert remote_index.ensure_fresh() is None
+        assert not idx.exists()
+
+    def test_invariant_failure_keeps_cached_copy(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, _ = isolate_cache
+        idx.write_bytes(SAMPLE_BODY)
+
+        # A poisoned index that's mostly empty must NOT overwrite the cache.
+        bad_body = json.dumps(
+            {
+                "schema_version": 4,
+                "endpoints": [],
+                "error_codes": [],
+                "schemas": [],
+            }
+        ).encode()
+        httpx_mock.add_response(
+            url=remote_index.REMOTE_INDEX_URL, content=bad_body
+        )
+
+        path = remote_index.ensure_fresh()
+        assert path == idx
+        # Cached copy preserved.
+        assert idx.read_bytes() == SAMPLE_BODY
+
+    def test_invariant_failure_returns_none_when_uncached(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, _ = isolate_cache
+        bad_body = json.dumps(
+            {
+                "schema_version": 4,
+                "endpoints": [],
+                "error_codes": [],
+                "schemas": [],
+            }
+        ).encode()
+        httpx_mock.add_response(
+            url=remote_index.REMOTE_INDEX_URL, content=bad_body
+        )
+        assert remote_index.ensure_fresh() is None
+        assert not idx.exists()
+
+    def test_invariant_failure_on_schema_version_mismatch(
+        self, httpx_mock: HTTPXMock, isolate_cache
+    ):
+        idx, _ = isolate_cache
+        bad_body = json.dumps(
+            {
+                "schema_version": 999,
+                "endpoints": [{} for _ in range(20)],
+                "error_codes": [{} for _ in range(40)],
+                "schemas": [{} for _ in range(10)],
+            }
+        ).encode()
+        httpx_mock.add_response(
+            url=remote_index.REMOTE_INDEX_URL, content=bad_body
+        )
         assert remote_index.ensure_fresh() is None
         assert not idx.exists()
 


### PR DESCRIPTION
## Summary

Responds to six findings from an external (OpenAI Codex) code review of the repo. Triaged each before fixing — sticking with auto-merge on the refresh workflow but tightening the gates rather than scrapping it; declining to pin the github-remote tier to release tags (defeats the daily-refresh design). Defense-in-depth via structural invariants instead.

- **codegen** — curl bodies emit via heredoc (`--data-binary @- <<'JSON'`), so apostrophes/backticks/`$` in JSON strings no longer break the generated snippet.
- **fetcher** — async path now shares the sync retry policy (3 attempts, exponential backoff, transient transport/5xx/429 only). New shared `run_async` helper handles the "called from inside an event loop" case.
- **cache** — public `DocsCache.put` / `put_many` replace the private `_entries` reach-around in `warm_vipmp_cache`; the batch path now does one atomic write instead of N fsyncs.
- **remote_index** — fetched indexes must pass structural floors (`schema_version` match, `endpoints≥10`, `error_codes≥20`, `schemas≥5`) before overwriting the cached copy. Mass-deletion poisoning of `main` is rejected.
- **refresh-index workflow** — same invariants plus a parse-error-fraction gate run before the auto-merged PR opens, so a bad refresh fails the workflow rather than landing on `main`.

See `CHANGELOG.md` `[Unreleased]` for the full list with rationale.

## Test plan

- [x] Full pytest suite green (192/192, +7 new tests)
- [x] `ruff check src/ tests/` clean
- [x] `scripts/smoke_test.py` green
- [x] CI (build 3.12 / 3.13) green on this PR
- [ ] Manual review of the workflow change — first refresh-index run after merge should still succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)