### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-03
+
 ### Security / hardening (response to external code review)
 - **Curl snippets now use a heredoc body** (`codegen.py`). The previous
   `-d '{...}'` form silently broke whenever a JSON string value

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "vipmp-docs-mcp",
   "display_name": "Adobe VIP Marketplace Docs",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
   "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes — without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.8.0"
+version = "0.9.0"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Stamps the `[Unreleased]` CHANGELOG block as `0.9.0` (2026-05-03) and bumps `pyproject.toml` + `manifest.json` to match. Merging this and pushing the `v0.9.0` tag triggers the PyPI publish, the MCPB pack, and the GitHub Release auto-creation.

Highlights (full list in `CHANGELOG.md` `[0.9.0]`):
- Security / hardening pass in response to external (OpenAI Codex) code review — curl-snippet heredoc body, async-fetcher retries, shared `run_async` helper, public `DocsCache.put` / `put_many`, structural invariants on the github-remote tier, and an invariant gate in the refresh workflow.

## Test plan

- [x] `pytest -q` — 192/192 green locally
- [x] `ruff check src/ tests/` clean
- [x] `scripts/smoke_test.py` green
- [x] CI green on this PR
- [ ] After merge: tag `v0.9.0`, verify `publish-pypi.yml` and `publish-mcpb.yml` succeed, GitHub Release appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)