### PR TITLE
fix(refresh): fail loud when Adobe sitemap returns too few vipmp paths

### DIFF
--- a/.github/workflows/refresh-index.yml
+++ b/.github/workflows/refresh-index.yml
@@ -100,6 +100,57 @@ jobs:
           )
           PY
 
+      - name: Capture Adobe response on rebuild failure
+        # When the rebuild step fails (typically because Adobe's sitemap.xml
+        # came back with too few vipmp paths — see MIN_VIPMP_SITEMAP_PATHS
+        # in autositemap.py), snapshot Adobe's raw response from the runner
+        # so we can compare against a known-good local capture. Uploaded as
+        # a workflow artifact below.
+        if: failure() && steps.rebuild.outcome == 'failure'
+        run: |
+          python - <<'PY'
+          import pathlib
+
+          import httpx
+
+          headers = {
+              "User-Agent": "Mozilla/5.0 (compatible; SWOVIPMPDocsMCP/0.2)",
+              "Accept": "text/html,application/xhtml+xml",
+              "Accept-Encoding": "gzip, deflate",
+          }
+          response = httpx.get(
+              "https://developer.adobe.com/sitemap.xml",
+              headers=headers,
+              follow_redirects=True,
+              timeout=30,
+          )
+          out = pathlib.Path("adobe-sitemap-debug")
+          out.mkdir(exist_ok=True)
+          (out / "status.txt").write_text(
+              f"{response.status_code} {response.reason_phrase}\n",
+              encoding="utf-8",
+          )
+          (out / "headers.txt").write_text(
+              "\n".join(f"{k}: {v}" for k, v in response.headers.items()),
+              encoding="utf-8",
+          )
+          (out / "body.xml").write_text(response.text, encoding="utf-8")
+          (out / "summary.txt").write_text(
+              f"status={response.status_code}\n"
+              f"body_bytes={len(response.text)}\n"
+              f"vipmp_docs_count={response.text.count('/vipmp/docs/')}\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload Adobe response artifact
+        if: failure() && steps.rebuild.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: adobe-sitemap-debug
+          path: adobe-sitemap-debug/
+          retention-days: 14
+
       - name: Validate structural invariants
         # Fail-loud guard against poisoning / parser regressions before the
         # PR ever opens. Same floors that `remote_index._check_invariants`

--- a/src/vipmp_docs_mcp/autositemap.py
+++ b/src/vipmp_docs_mcp/autositemap.py
@@ -46,6 +46,14 @@ PACKAGE_SITEMAP_PATH = Path(__file__).parent / "data" / "sitemap.json"
 # Schema version — bump on breaking changes to the persisted JSON shape.
 SITEMAP_SCHEMA_VERSION = 1
 
+# Fail-loud floor for the vipmp path count parsed out of Adobe's sitemap.xml.
+# Adobe currently publishes ~86 vipmp paths; if a successful fetch returns
+# fewer than this, something has gone wrong on Adobe's side (CDN/bot
+# protection serving a stripped sitemap, namespace change, etc.) and we
+# would rather fail loudly than build an empty index. See refresh-index
+# workflow runs on 2026-05-13 / 2026-05-14 for the original incident.
+MIN_VIPMP_SITEMAP_PATHS = 50
+
 
 def _fetch_sitemap_paths() -> list[str]:
     """Fetch Adobe's sitemap.xml and return normalized vipmp doc paths."""
@@ -55,7 +63,21 @@ def _fetch_sitemap_paths() -> list[str]:
     urls = [u.find("sm:loc", ns).text or "" for u in root.findall("sm:url", ns)]
     vipmp = [u.replace(BASE_URL, "") for u in urls if "/vipmp/docs/" in u]
     paths = sorted({normalize_path(p) for p in vipmp})
-    log.info("fetched %d vipmp paths from %s", len(paths), SITEMAP_XML_PATH)
+    log.info(
+        "fetched %d vipmp paths from %s (response=%d bytes, %d total urls)",
+        len(paths),
+        SITEMAP_XML_PATH,
+        len(xml),
+        len(urls),
+    )
+    if len(paths) < MIN_VIPMP_SITEMAP_PATHS:
+        raise FetchError(
+            f"Adobe sitemap.xml returned only {len(paths)} vipmp paths "
+            f"(minimum {MIN_VIPMP_SITEMAP_PATHS}); response was {len(xml)} bytes, "
+            f"{len(urls)} total URLs, root tag {root.tag!r}. "
+            "Likely a CDN/bot-protection response — see workflow artifact "
+            "for the raw body."
+        )
     return paths
 
 
@@ -161,7 +183,18 @@ def build_sitemap(throttle: float = 0.0) -> list[SitemapEntry]:
 
 
 def save_sitemap(entries: list[SitemapEntry], path: Path = SITEMAP_JSON_PATH) -> None:
-    """Persist the sitemap to JSON (atomic write)."""
+    """Persist the sitemap to JSON (atomic write).
+
+    Refuses to overwrite an existing healthy file with an empty entries
+    list — defense-in-depth so a buggy build_sitemap() that returns ``[]``
+    can't corrupt the shipped fallback.
+    """
+    if not entries and path.exists():
+        existing = load_sitemap(path)
+        if existing:
+            raise ValueError(
+                f"refusing to overwrite {path} ({len(existing)} entries) with empty entries list"
+            )
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "schema_version": SITEMAP_SCHEMA_VERSION,
@@ -211,7 +244,9 @@ def get_active_sitemap() -> list[SitemapEntry]:
     if package:
         log.debug("no per-user sitemap; using package-shipped fallback")
         return package
-    log.warning("no sitemap available (user cache missing and package "
-                "fallback unreadable) — search and listing tools will "
-                "return empty results until `refresh_vipmp_sitemap` runs")
+    log.warning(
+        "no sitemap available (user cache missing and package "
+        "fallback unreadable) — search and listing tools will "
+        "return empty results until `refresh_vipmp_sitemap` runs"
+    )
     return []

--- a/tests/test_autositemap.py
+++ b/tests/test_autositemap.py
@@ -17,10 +17,14 @@ import pytest
 
 from vipmp_docs_mcp import autositemap
 from vipmp_docs_mcp.autositemap import (
+    MIN_VIPMP_SITEMAP_PATHS,
     SITEMAP_SCHEMA_VERSION,
+    _fetch_sitemap_paths,
     get_active_sitemap,
     merge_curated_tags,
+    save_sitemap,
 )
+from vipmp_docs_mcp.fetcher import FetchError
 
 
 def _payload(entries: list[dict]) -> str:
@@ -136,3 +140,76 @@ class TestMergeCuratedTags:
         assert tags == sorted(tags)
         assert tags.count("oauth") == 1  # no duplicates
         assert "zzz-last" in tags
+
+
+class TestFetchSitemapPathsFailLoud:
+    """Guard added after the 2026-05-13/14 incident where Adobe's CDN
+    returned a sitemap.xml with zero vipmp paths and the build silently
+    produced an empty index."""
+
+    def _xml(self, vipmp_count: int = 0, extra_urls: int = 5) -> str:
+        urls = [
+            f"<url><loc>https://developer.adobe.com/other/{i}/</loc></url>"
+            for i in range(extra_urls)
+        ] + [
+            f"<url><loc>https://developer.adobe.com/vipmp/docs/page-{i}</loc></url>"
+            for i in range(vipmp_count)
+        ]
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+            + "".join(urls)
+            + "</urlset>"
+        )
+
+    def test_raises_when_no_vipmp_paths(self, monkeypatch: pytest.MonkeyPatch):
+        body = self._xml(vipmp_count=0, extra_urls=12)
+        monkeypatch.setattr(autositemap, "fetch_page_html", lambda *a, **k: body)
+        with pytest.raises(FetchError) as exc_info:
+            _fetch_sitemap_paths()
+        msg = str(exc_info.value)
+        assert "0 vipmp paths" in msg
+        assert str(len(body)) in msg  # response byte count for diagnosis
+        assert "12 total URLs" in msg
+
+    def test_raises_when_below_floor(self, monkeypatch: pytest.MonkeyPatch):
+        body = self._xml(vipmp_count=MIN_VIPMP_SITEMAP_PATHS - 1, extra_urls=0)
+        monkeypatch.setattr(autositemap, "fetch_page_html", lambda *a, **k: body)
+        with pytest.raises(FetchError, match=r"minimum 50"):
+            _fetch_sitemap_paths()
+
+    def test_passes_at_floor(self, monkeypatch: pytest.MonkeyPatch):
+        body = self._xml(vipmp_count=MIN_VIPMP_SITEMAP_PATHS, extra_urls=0)
+        monkeypatch.setattr(autositemap, "fetch_page_html", lambda *a, **k: body)
+        paths = _fetch_sitemap_paths()
+        assert len(paths) == MIN_VIPMP_SITEMAP_PATHS
+
+
+class TestSaveSitemapOverwriteGuard:
+    def test_refuses_to_overwrite_healthy_file_with_empty(self, tmp_path: Path):
+        path = tmp_path / "sitemap.json"
+        path.write_text(_payload([{"path": "/vipmp/docs/x", "title": "Existing", "tags": []}]))
+        with pytest.raises(ValueError, match=r"refusing to overwrite"):
+            save_sitemap([], path)
+        # File untouched.
+        assert json.loads(path.read_text())["entries"][0]["title"] == "Existing"
+
+    def test_overwrites_empty_file_with_empty(self, tmp_path: Path):
+        """An existing-but-empty file is fine to overwrite — there's nothing to lose."""
+        path = tmp_path / "sitemap.json"
+        path.write_text(_payload([]))
+        save_sitemap([], path)  # no exception
+        assert json.loads(path.read_text())["entries"] == []
+
+    def test_writes_normally_when_file_missing(self, tmp_path: Path):
+        path = tmp_path / "sitemap.json"
+        save_sitemap([], path)  # no exception, creates the file
+        assert path.exists()
+        assert json.loads(path.read_text())["entries"] == []
+
+    def test_writes_normally_with_non_empty_entries(self, tmp_path: Path):
+        """Non-empty payload always writes, even over an existing healthy file."""
+        path = tmp_path / "sitemap.json"
+        path.write_text(_payload([{"path": "/vipmp/docs/old", "title": "Old", "tags": []}]))
+        save_sitemap([{"path": "/vipmp/docs/new", "title": "New", "tags": []}], path)
+        assert json.loads(path.read_text())["entries"][0]["title"] == "New"


### PR DESCRIPTION
## Summary

The daily `Refresh structured index` workflow has been failing for two consecutive runs ([2026-05-13](https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/actions/runs/25780566597), [2026-05-14](https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/actions/runs/25843833084)) with `Index failed structural invariants: 'endpoints' has 0 entries, minimum 10`. Last green run: 2026-05-12.

**What's actually happening:** Adobe's `/sitemap.xml` responds 200, XML parses fine, but the filtered list of `/vipmp/docs/` paths comes back empty (locally the same fetch returns 86 paths in ~1.3s). `build_sitemap()` silently returns `[]`, `save_sitemap([], PACKAGE_SITEMAP_PATH)` wipes the package fallback to `{"entries": []}` on the runner, and `build_index()` produces 0 endpoints. The validate step catches it at the end — main is safe — but the error points at the invariant, not the real failure (the sitemap fetch).

Most likely cause: Adobe's CDN (Akamai) started treating Azure eastus2 GitHub Actions egress as a bot around 2026-05-12 and is returning a stripped sitemap. This PR doesn't fix that — but it makes the failure mode loud and self-documenting, and gives us the data to confirm the hypothesis.

### Changes

- **`autositemap._fetch_sitemap_paths`**: new `MIN_VIPMP_SITEMAP_PATHS = 50` floor (current count is 86; floor leaves headroom but catches catastrophic loss). Raises `FetchError` with response byte count, total URL count, and root tag for diagnosis.
- **`autositemap.save_sitemap`**: refuses to overwrite an existing healthy file with an empty entries list — defense-in-depth against future regressions that produce `[]`.
- **`refresh-index.yml`**: on rebuild failure, re-fetches Adobe's sitemap.xml with the same UA/headers and uploads `status` / `headers` / `body.xml` / `summary` as the `adobe-sitemap-debug` artifact (14-day retention). The next failing run gives us the exact bytes Adobe is serving to the runner.
- **`tests/test_autositemap.py`**: seven new cases covering the fail-loud floor (no-vipmp, below-floor, at-floor) and the overwrite guard (refuses overwrite, empty-over-empty OK, missing-file OK, non-empty payload always writes).

## Test plan

- [x] `pytest tests/test_autositemap.py -q` — 15 passed (8 existing + 7 new)
- [x] Full suite: `pytest -q` — 199 passed
- [x] `ruff check src/ tests/` — clean
- [x] Live happy-path sanity check: `_fetch_sitemap_paths()` against Adobe's real sitemap still returns 86 paths locally
- [ ] After merge: trigger `workflow_dispatch` on `refresh-index.yml` — expect the rebuild step to fail with the new `FetchError` (clear message naming response shape), the diagnostic step to run, and the `adobe-sitemap-debug` artifact to be uploaded. Validate step gets skipped; no PR is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)