### PR TITLE
chore(data): refresh sitemap + structured index from Adobe docs

### DIFF
--- a/src/vipmp_docs_mcp/data/index.json
+++ b/src/vipmp_docs_mcp/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 4,
-  "built_at": 1781157750.5473156,
+  "built_at": 1782193673.6394742,
   "source_sitemap_size": 86,
   "pages_parsed": 86,
   "parse_errors": [],
@@ -634,6 +634,20 @@
     {
       "code": "LGA_QTY_LEVEL_MISMATCH",
       "reason": "MOQ does not fall between respective level cap quantities.",
+      "endpoint": null,
+      "response": null,
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "T&C_ACCEPTANCE_REQUIRED",
+      "reason": "The customer has not accepted the VIP T&C",
+      "endpoint": null,
+      "response": null,
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "VIP_CUSTOM_MIGRATION_BLOCK",
+      "reason": "Not a traditional VIP Indirect contract, so migration is currently not supported.",
       "endpoint": null,
       "response": null,
       "docs_path": "/vipmp/docs/references/error-handling"
@@ -1801,6 +1815,22 @@
   ],
   "releases": [
     {
+      "date": "2026-06-23",
+      "raw_date": "June 23, 2026",
+      "section": "api_changes",
+      "changes": [
+        {
+          "title": "Flexible discounts for Switch Orders (Mid-term upgrade discounts)",
+          "body": "Partners can now apply flexible discount codes when customers switch products mid-term using POST /v3/customers/{customerId}/orders with orderType: SWITCH or PREVIEW_SWITCH . This allows promotional pricing to be offered at the point of upgrade, instead of being limited to renewals.\n\nWhat changed\n\nThe following APIs have been updated:\n\n- Preview Switch Order ( PREVIEW_SWITCH ): Accepts lineItems[].flexDiscountCodes in the request. Returns lineItems[].flexDiscounts in the response, indicating whether each code was successfully applied.\n\n- Create Switch Order ( SWITCH ): Accepts lineItems[].flexDiscountCodes in the request. Returns lineItems[].flexDiscounts in the response.\n\n- Get Order ( GET /v3/customers/{customerId}/orders/{orderId} ): Returns lineItems[].flexDiscounts for SWITCH orders, in addition to the existing behavior for other orderTypes , including NEW orders.\n\n- Get Order History ( GET /v3/customers/{customerId}/orders ): Returns lineItems[].flexDiscounts for SWITCH orders in the order history list.\n\nImportant: flexDiscountCodes apply only to lineItems (the target product items being switched to). Codes on cancellingItems (the source product being cancelled) are not accepted or returned.\n\nWhy it matters\n\nPartners can now incentivize customers to upgrade products during their active subscription term by applying promotional discounts at the time of the switch. Previously, flexible discounts were only available on new orders and renewals. This enables upsell campaigns where discount codes can be offered to customers making mid-term product upgrades.\n\nAction required\n\nAction Details Add flexDiscountCodes to switch order requests Include lineItems[].flexDiscountCodes (array of strings) in your PREVIEW_SWITCH and SWITCH order requests to apply a flexible discount. This field is optional. Check flexDiscounts[].result in the response Verify that result: \"SUCCESS\" is returned for each applied code before confirming the discount to the customer. Update Get Order and Get Order History API integrations If your integration reads order details or history for SWITCH orders, expect the lineItems[].flexDiscounts field to now be present in responses. Use Preview Switch Order before placing the order Call PREVIEW_SWITCH first to confirm discount applicability and see the discounted pricing before committing the order.\n\nFor more information, see Manage Flexible Discounts ."
+        },
+        {
+          "title": "Flexible Discounts for 3-Year Commitments (3YC)",
+          "body": "Partners can discover and apply flexible discounts specifically designed for customers who are new to 3YC (orders that make them 3YC-compliant) or existing 3YC customers, including cases where minimum purchase quantity (MPQ) thresholds are met. Promotions can be reused and applied to the first term, the current term, or the full 3YC commitment duration.\n\nWhy it matters\n\nPartners can now present 3YC-specific promotional pricing to eligible customers to incentivize new 3-year commitments or to reward existing 3YC subscribers. This removes the need for manual outreach to identify eligible customers.\n\nAction required\n\nAction Details Discover 3YC promotions through Get Flexible Discounts Call GET /v3/flex-discounts . Apply the discount code on the order Include the flexDiscountCodes in your NEW or RENEWAL order request. Eligibility is evaluated dynamically.\n\nFor more information, see Manage Flexible Discounts ."
+        }
+      ],
+      "docs_path": "/vipmp/docs/release-notes"
+    },
+    {
       "date": "2026-06-09",
       "raw_date": "June 09, 2026",
       "section": "api_changes",
@@ -2067,7 +2097,7 @@
       "changes": [
         {
           "title": "Upcoming changes",
-          "body": "Flexible discounts for Switch Orders (Mid-term upgrade discounts)\n\nExpected release: June 2026\n\nPartners can now apply flexible discount codes when customers switch products mid-term using POST /v3/customers/{customerId}/orders with orderType: SWITCH or PREVIEW_SWITCH . This allows promotional pricing to be offered at the point of upgrade, not just at renewal.\n\nWhat changed\n\nThe following APIs have been updated:\n\n- Preview Switch Order ( PREVIEW_SWITCH ): Accepts lineItems[].flexDiscountCodes in the request. Returns lineItems[].flexDiscounts in the response, showing whether each code was successfully applied.\n\n- Create Switch Order ( SWITCH ): Accepts lineItems[].flexDiscountCodes in the request. Returns lineItems[].flexDiscounts in the response.\n\n- Get Order ( GET /v3/customers/{customerId}/orders/{orderId} ): Returns lineItems[].flexDiscounts for SWITCH orders, in addition to the existing behavior for other orderTypes , including NEW orders.\n\n- Get Order History ( GET /v3/customers/{customerId}/orders ): Returns lineItems[].flexDiscounts for SWITCH orders in the order history list.\n\nImportant: flexDiscountCodes apply only to lineItems (the target product items being switched to). Codes on cancellingItems (the source product being cancelled) are not accepted or returned.\n\nWhy it matters\n\nPartners can now incentivize customers to upgrade products during their active subscription term by applying promotional discounts at the time of the switch. Previously, flexible discounts were only available on new orders and renewals. This enables upsell campaigns where discount codes can be offered to customers making mid-term product upgrades.\n\nAction required\n\nFor more information, see Manage Flexible Discounts .\n\nFlexible Discounts for 3-Year Commitments (3YC)\n\nExpected release: June 2026\n\nPartners can discover and apply flexible discounts specifically designed for customers who are new to 3YC (orders that make them 3YC-compliant) or existing 3YC customers, including cases where minimum purchase quantity (MPQ) thresholds are met. Promotions can be reused and applied to the first term, the current term, or the full 3YC commitment duration.\n\nWhy it matters\n\nPartners can now present 3YC-specific promotional pricing to eligible customers to incentivize new 3-year commitments or to reward existing 3YC subscribers. This removes the need for manual outreach to identify eligible customers.\n\nAction required\n\nFor more information, see Manage Flexible Discounts .\n\nChurn and seat expansion propensity are now surfaced in the Recommendations API\n\nExpected release: June 2026\n\nPartners can now see churn risk and seat expansion signals for each customer through the existing Fetch Recommendations ( POST /v3/recommendations ) API.\n\nWhat changed?\n\nThe Recommendations API response now includes a churn object and a seatExpansion object. Each contains a probability rating ( HIGH , MEDIUM , or LOW ), a refreshDate , and a reasons array with up to seven leading indicators ordered by relevance. Seat expansion also includes predictedAddonSize with the expected number of additional seats.\n\nImportant: An empty object {} for either node means propensity data is not available for that customer. Do not interpret {} as LOW risk or LOW expansion potential.\n\nWhy it matters?\n\nPartners can now identify at-risk customers and high-growth opportunities using data-driven signals, rather than relying on anecdotal indicators or waiting for account-manager outreach.\n\nAction required\n\nFor more information, see Propensity Intelligence ."
+          "body": "Churn and seat expansion propensity are now surfaced in the Recommendations API\n\nExpected release: July 2026\n\nPartners can now see churn risk and seat expansion signals for each customer through the existing Fetch Recommendations ( POST /v3/recommendations ) API.\n\nWhat changed?\n\nSetting the request parameter includePropensity to true fetches churn and seatExpansion arrays. Each contains a probability rating ( HIGH , MEDIUM , or LOW ), a refreshDate , and a reasons array with up to seven leading indicators ordered by relevance.\n\nSeat expansion also includes predictedAddonSize with the expected number of additional seats.\n\nImportant: An empty object {} for either node means propensity data is not available for that customer. Do not interpret {} as LOW risk or LOW expansion potential.\n\nWhy it matters\n\nPartners can now identify at-risk customers and high-growth opportunities using data-driven signals, rather than relying on anecdotal indicators or waiting for account-manager outreach.\n\nAction required\n\nFor more information, see Propensity Intelligence ."
         }
       ],
       "docs_path": "/vipmp/docs/release-notes/upcoming-releases"

--- a/src/vipmp_docs_mcp/data/sitemap.json
+++ b/src/vipmp_docs_mcp/data/sitemap.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": 1781157740.9984577,
+  "generated_at": 1782193669.470627,
   "entries": [
     {
       "path": "/vipmp/docs",


### PR DESCRIPTION
Automated refresh of `src/vipmp_docs_mcp/data/sitemap.json` and `src/vipmp_docs_mcp/data/index.json` from live Adobe docs.

**Trigger:** scheduled (weekly)

## Build stats

| | |
|---|---|
| Sitemap size | 86 |
| Pages parsed | 86 |
| Endpoints | 22 |
| Error codes | 67 |
| Schemas | 18 |
| Parse errors | 0 |
| Sitemap build time | 7.1s |
| Index build time | 7.4s |

## Parse errors (if any)

See the workflow run artifact and/or the diff.

## What to check before merging

- Large changes in **endpoints** / **error_codes** / **schemas** counts — could mean Adobe restructured, or our parser regressed.
- Any **parse_errors** entries — new pages we can't parse.
- Spot-check the JSON diff for obvious junk (empty strings, stray HTML leaking through, etc.).

Downstream installs (`pip install -e .`, `uvx --from git+...`) pick up the new baseline on the next cache refresh, and the v0.7.0+ github-remote tier now fetches it within 12 h without a PyPI release.

---

🤖 Generated by [`.github/workflows/refresh-index.yml`](.github/workflows/refresh-index.yml) — auto-merged once CI passes.