### PR TITLE
chore(data): refresh sitemap + structured index from Adobe docs

### DIFF
--- a/src/vipmp_docs_mcp/data/index.json
+++ b/src/vipmp_docs_mcp/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 4,
-  "built_at": 1782193673.6394742,
+  "built_at": 1782366430.5416439,
   "source_sitemap_size": 86,
   "pages_parsed": 86,
   "parse_errors": [],
@@ -2097,7 +2097,7 @@
       "changes": [
         {
           "title": "Upcoming changes",
-          "body": "Churn and seat expansion propensity are now surfaced in the Recommendations API\n\nExpected release: July 2026\n\nPartners can now see churn risk and seat expansion signals for each customer through the existing Fetch Recommendations ( POST /v3/recommendations ) API.\n\nWhat changed?\n\nSetting the request parameter includePropensity to true fetches churn and seatExpansion arrays. Each contains a probability rating ( HIGH , MEDIUM , or LOW ), a refreshDate , and a reasons array with up to seven leading indicators ordered by relevance.\n\nSeat expansion also includes predictedAddonSize with the expected number of additional seats.\n\nImportant: An empty object {} for either node means propensity data is not available for that customer. Do not interpret {} as LOW risk or LOW expansion potential.\n\nWhy it matters\n\nPartners can now identify at-risk customers and high-growth opportunities using data-driven signals, rather than relying on anecdotal indicators or waiting for account-manager outreach.\n\nAction required\n\nFor more information, see Propensity Intelligence ."
+          "body": "Churn and seat expansion propensity are now surfaced in the Recommendations API\n\nExpected release: July 2026\n\nPartners can now see churn risk and seat expansion signals for each customer through the existing Fetch Recommendations ( POST /v3/recommendations ) API.\n\nWhat changed?\n\nSetting the request parameter includePropensity to true fetches churn and seatExpansion arrays. Each contains a probability rating ( HIGH , MEDIUM , or LOW ), a refreshDate , and a reasons array with up to seven leading indicators ordered by relevance.\n\nSeat expansion also includes predictedAddonSize with the expected number of additional seats.\n\nImportant: An empty object {} for either node means propensity data is not available for that customer. Do not interpret {} as LOW risk or LOW expansion potential.\n\nWhy it matters\n\nPartners can now identify at-risk customers and high-growth opportunities using data-driven signals, rather than relying on anecdotal indicators or waiting for account-manager outreach.\n\nAction required\n\nFor more information, see Propensity Intelligence .\n\nTesting Propensity Signals in sandbox\n\nA set of 13 predefined test seeds is configured in the Sandbox so you can exercise every combination of rating level and empty-array behavior during integration testing. Each seed returns a fixed response.\n\nFor more information, see Testing Propensity Signals in sandbox ."
         }
       ],
       "docs_path": "/vipmp/docs/release-notes/upcoming-releases"

--- a/src/vipmp_docs_mcp/data/sitemap.json
+++ b/src/vipmp_docs_mcp/data/sitemap.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": 1782193669.470627,
+  "generated_at": 1782366425.7081997,
   "entries": [
     {
       "path": "/vipmp/docs",


### PR DESCRIPTION
Automated refresh of `src/vipmp_docs_mcp/data/sitemap.json` and `src/vipmp_docs_mcp/data/index.json` from live Adobe docs.

**Trigger:** scheduled (weekly)

## Build stats

| | |
|---|---|
| Sitemap size | 86 |
| Pages parsed | 86 |
| Endpoints | 22 |
| Error codes | 67 |
| Schemas | 18 |
| Parse errors | 0 |
| Sitemap build time | 10.6s |
| Index build time | 8.0s |

## Parse errors (if any)

See the workflow run artifact and/or the diff.

## What to check before merging

- Large changes in **endpoints** / **error_codes** / **schemas** counts — could mean Adobe restructured, or our parser regressed.
- Any **parse_errors** entries — new pages we can't parse.
- Spot-check the JSON diff for obvious junk (empty strings, stray HTML leaking through, etc.).

Downstream installs (`pip install -e .`, `uvx --from git+...`) pick up the new baseline on the next cache refresh, and the v0.7.0+ github-remote tier now fetches it within 12 h without a PyPI release.

---

🤖 Generated by [`.github/workflows/refresh-index.yml`](.github/workflows/refresh-index.yml) — auto-merged once CI passes.