### PR TITLE
ci: auto-bump minor version and release on bot PR merge, gate publish on CI

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,0 +1,123 @@
+name: Auto version bump on bot PR merge
+
+# When a bot-authored PR merges into main (branch name prefixed `bot/`,
+# e.g. bot/refresh-index — the convention any future bot workflow, such
+# as link-check if it starts opening PRs, should also follow), bump the
+# minor version in pyproject.toml + manifest.json, commit straight to
+# main, wait for CI to pass on that commit, and — only if CI succeeds —
+# tag vX.(Y+1).0. The tag push triggers publish-mcpb.yml / publish-pypi.yml,
+# which each re-verify CI succeeded before publishing (see wait-for-ci job
+# in those workflows) so a manually pushed tag gets the same protection.
+#
+# If CI fails, the version bump still lands on main but nothing is tagged
+# or released — a human has to investigate and tag manually once fixed.
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: read
+
+concurrency:
+  # Serialize bumps so two bot PRs merging close together can't race and
+  # stomp each other's version bump.
+  group: auto-version-bump
+  cancel-in-progress: false
+
+jobs:
+  bump-and-release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'bot/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          # Admin PAT, not GITHUB_TOKEN — needed to push straight to main
+          # and push the tag below, bypassing the "changes must go through
+          # a PR" ruleset. Same PAT/rationale as the auto-merge step in
+          # refresh-index.yml.
+          token: ${{ secrets.REFRESH_INDEX_PAT }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump minor version
+        id: bump
+        run: |
+          python3 - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          pyproject = Path("pyproject.toml")
+          text = pyproject.read_text(encoding="utf-8")
+          match = re.search(r'^version = "(\d+)\.(\d+)\.(\d+)"$', text, flags=re.MULTILINE)
+          if not match:
+              raise SystemExit("Could not find version in pyproject.toml")
+          major, minor, _patch = (int(g) for g in match.groups())
+          new_version = f"{major}.{minor + 1}.0"
+
+          text = text[: match.start()] + f'version = "{new_version}"' + text[match.end() :]
+          pyproject.write_text(text, encoding="utf-8")
+
+          manifest = Path("manifest.json")
+          data = json.loads(manifest.read_text(encoding="utf-8"))
+          data["version"] = new_version
+          manifest.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+          Path("bump_version_output.txt").write_text(new_version, encoding="utf-8")
+          PY
+          echo "version=$(cat bump_version_output.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Commit version bump
+        run: |
+          git add pyproject.toml manifest.json
+          git commit -m "chore(release): bump version to ${{ steps.bump.outputs.version }}
+
+          Triggered by merge of #${{ github.event.pull_request.number }} (${{ github.event.pull_request.head.ref }})."
+          git push origin main
+
+      - name: Wait for CI to pass on this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(git rev-parse HEAD)
+          echo "Waiting for the CI workflow to complete on $SHA..."
+          for i in $(seq 1 60); do
+            RUN_JSON=$(gh run list --repo "${{ github.repository }}" --workflow ci.yml --commit "$SHA" --json status,conclusion --jq '.[0]')
+            if [ -n "$RUN_JSON" ] && [ "$RUN_JSON" != "null" ]; then
+              STATUS=$(echo "$RUN_JSON" | jq -r '.status')
+              CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion')
+              if [ "$STATUS" = "completed" ]; then
+                if [ "$CONCLUSION" = "success" ]; then
+                  echo "CI succeeded for $SHA."
+                  exit 0
+                fi
+                echo "::error::CI run for $SHA concluded '$CONCLUSION' — version bump landed on main but no tag/release will be created."
+                exit 1
+              fi
+              echo "CI status: $STATUS (attempt $i/60)"
+            else
+              echo "No CI run found yet for $SHA (attempt $i/60)"
+            fi
+            sleep 10
+          done
+          echo "::error::Timed out after 10m waiting for CI to complete on $SHA"
+          exit 1
+
+      - name: Tag release
+        env:
+          GH_TOKEN: ${{ secrets.REFRESH_INDEX_PAT }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          git tag -a "v$VERSION" -m "v$VERSION"
+          git push origin "v$VERSION"

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -23,7 +23,49 @@ permissions:
   contents: write
 
 jobs:
+  wait-for-ci:
+    # Tag pushes don't wait on ci.yml (different trigger entirely), so a
+    # bad commit that somehow got tagged could otherwise publish a bundle
+    # straight to a GitHub Release. Poll for the CI run on this exact
+    # commit SHA and refuse to continue unless it succeeded. Skipped for
+    # workflow_dispatch reruns with no tag ref — see the downstream job's
+    # `if`.
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      actions: read
+    steps:
+      - name: Wait for CI to pass on this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA="${{ github.sha }}"
+          echo "Waiting for the CI workflow to complete on $SHA..."
+          for i in $(seq 1 60); do
+            RUN_JSON=$(gh run list --repo "${{ github.repository }}" --workflow ci.yml --commit "$SHA" --json status,conclusion --jq '.[0]')
+            if [ -n "$RUN_JSON" ] && [ "$RUN_JSON" != "null" ]; then
+              STATUS=$(echo "$RUN_JSON" | jq -r '.status')
+              CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion')
+              if [ "$STATUS" = "completed" ]; then
+                if [ "$CONCLUSION" = "success" ]; then
+                  echo "CI succeeded for $SHA."
+                  exit 0
+                fi
+                echo "::error::CI run for $SHA concluded '$CONCLUSION' — refusing to publish."
+                exit 1
+              fi
+              echo "CI status: $STATUS (attempt $i/60)"
+            else
+              echo "No CI run found yet for $SHA (attempt $i/60)"
+            fi
+            sleep 10
+          done
+          echo "::error::Timed out after 10m waiting for CI to complete on $SHA"
+          exit 1
+
   pack-and-release:
+    needs: wait-for-ci
+    if: always() && (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -27,7 +27,48 @@ on:
   workflow_dispatch:
 
 jobs:
+  wait-for-ci:
+    # Tag pushes don't wait on ci.yml (different trigger entirely), so a
+    # bad commit that somehow got tagged could otherwise publish straight
+    # to PyPI. Poll for the CI run on this exact commit SHA and refuse to
+    # continue unless it succeeded. Skipped for workflow_dispatch reruns
+    # with no tag ref — see the downstream job's `if`.
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      actions: read
+    steps:
+      - name: Wait for CI to pass on this commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA="${{ github.sha }}"
+          echo "Waiting for the CI workflow to complete on $SHA..."
+          for i in $(seq 1 60); do
+            RUN_JSON=$(gh run list --repo "${{ github.repository }}" --workflow ci.yml --commit "$SHA" --json status,conclusion --jq '.[0]')
+            if [ -n "$RUN_JSON" ] && [ "$RUN_JSON" != "null" ]; then
+              STATUS=$(echo "$RUN_JSON" | jq -r '.status')
+              CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion')
+              if [ "$STATUS" = "completed" ]; then
+                if [ "$CONCLUSION" = "success" ]; then
+                  echo "CI succeeded for $SHA."
+                  exit 0
+                fi
+                echo "::error::CI run for $SHA concluded '$CONCLUSION' — refusing to publish."
+                exit 1
+              fi
+              echo "CI status: $STATUS (attempt $i/60)"
+            else
+              echo "No CI run found yet for $SHA (attempt $i/60)"
+            fi
+            sleep 10
+          done
+          echo "::error::Timed out after 10m waiting for CI to complete on $SHA"
+          exit 1
+
   build-and-publish:
+    needs: wait-for-ci
+    if: always() && (needs.wait-for-ci.result == 'success' || needs.wait-for-ci.result == 'skipped')
     runs-on: ubuntu-latest
 
     # The "pypi" environment scopes the OIDC trust to this exact workflow


### PR DESCRIPTION
## Summary
- New `auto-version-bump.yml`: when a `bot/*`-branch PR (e.g. `bot/refresh-index`, and any future bot workflow following that naming convention) merges into `main`, bumps the minor version in `pyproject.toml` + `manifest.json`, commits to `main`, waits for CI to pass on that commit, then tags `vX.(Y+1).0` — which triggers the publish workflows.
- `publish-mcpb.yml` / `publish-pypi.yml`: both now start with a `wait-for-ci` job that polls for the CI run on the tagged commit and refuses to publish unless it succeeded. This protects both the new automated flow and any manually pushed tag.

## Notes
- `link-check.yml` doesn't currently open PRs (only issues on 404s), so this won't fire for it today — but it will automatically if that workflow is ever changed to open a `bot/link-check` PR, since the trigger matches on the `bot/` branch prefix rather than a specific workflow name.
- If CI fails after a bot-PR-triggered bump, the version bump still lands on `main` but no tag/release is created — a human needs to investigate and tag manually once fixed.

## Test plan
- [ ] Merge a `bot/refresh-index` PR (or manually trigger `refresh-index.yml` and let it open + auto-merge one) and confirm `auto-version-bump.yml` fires, bumps the minor version, waits for CI, and tags.
- [ ] Confirm `publish-mcpb.yml` / `publish-pypi.yml` run after that tag and only after CI succeeds.
- [ ] Confirm `workflow_dispatch` reruns of the publish workflows (no tag ref) still work as before (wait-for-ci skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)