### PR TITLE
fix: derive __version__ from installed package metadata

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "vipmp-docs-mcp",
   "display_name": "Adobe VIP Marketplace Docs",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
   "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes — without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.10.0"
+version = "0.11.0"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/vipmp_docs_mcp/__init__.py
+++ b/src/vipmp_docs_mcp/__init__.py
@@ -1,3 +1,8 @@
 """Adobe VIP Marketplace Docs MCP Server."""
 
-__version__ = "0.8.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("vipmp-docs-mcp")
+except PackageNotFoundError:
+    __version__ = "0.0.0"


### PR DESCRIPTION
## Summary
- `src/vipmp_docs_mcp/__init__.py` hardcoded `__version__ = "0.8.0"`, out of sync with `pyproject.toml` (0.10.0 at time of writing). `vipmp_server_info` was faithfully reporting the stale constant regardless of what was actually installed.
- Derive `__version__` from `importlib.metadata.version("vipmp-docs-mcp")` instead, falling back to `"0.0.0"` if the package isn't installed, so it can't drift from `pyproject.toml` again.
- Bumped release version to 0.11.0 (`pyproject.toml`, `manifest.json`) to ship the fix.

## Test plan
- [x] `uv run pytest -q` — 199 passed
- [x] `uv run python -c "from vipmp_docs_mcp import __version__; print(__version__)"` reports `0.11.0` once installed