### PR TITLE
feat: add list_vipmp_status_codes tool

### DIFF
--- a/.github/workflows/refresh-index.yml
+++ b/.github/workflows/refresh-index.yml
@@ -87,6 +87,7 @@ jobs:
               fh.write(f"sitemap_size={snap.source_sitemap_size}\n")
               fh.write(f"endpoints={len(snap.endpoints)}\n")
               fh.write(f"error_codes={len(snap.error_codes)}\n")
+              fh.write(f"status_codes={len(snap.status_codes)}\n")
               fh.write(f"schemas={len(snap.schemas)}\n")
               fh.write(f"parse_errors={len(snap.parse_errors)}\n")
               fh.write(f"sitemap_elapsed_seconds={sitemap_elapsed:.1f}\n")
@@ -169,6 +170,7 @@ jobs:
               MIN_ENDPOINTS,
               MIN_ERROR_CODES,
               MIN_SCHEMAS,
+              MIN_STATUS_CODES,
               _check_invariants,
               IndexInvariantError,
           )
@@ -204,6 +206,8 @@ jobs:
               f"(min {MIN_ENDPOINTS}), "
               f"error_codes={len(data.get('error_codes', []))} "
               f"(min {MIN_ERROR_CODES}), "
+              f"status_codes={len(data.get('status_codes', []))} "
+              f"(min {MIN_STATUS_CODES}), "
               f"schemas={len(data.get('schemas', []))} "
               f"(min {MIN_SCHEMAS}), "
               f"parse_errors={len(parse_errors)}/{sitemap_size}"
@@ -256,6 +260,7 @@ jobs:
             | Pages parsed | ${{ steps.rebuild.outputs.pages_parsed }} |
             | Endpoints | ${{ steps.rebuild.outputs.endpoints }} |
             | Error codes | ${{ steps.rebuild.outputs.error_codes }} |
+            | Status codes | ${{ steps.rebuild.outputs.status_codes }} |
             | Schemas | ${{ steps.rebuild.outputs.schemas }} |
             | Parse errors | ${{ steps.rebuild.outputs.parse_errors }} |
             | Sitemap build time | ${{ steps.rebuild.outputs.sitemap_elapsed_seconds }}s |

--- a/src/vipmp_docs_mcp/data/index.json
+++ b/src/vipmp_docs_mcp/data/index.json
@@ -1,6 +1,6 @@
 {
-  "schema_version": 4,
-  "built_at": 1782366430.5416439,
+  "schema_version": 5,
+  "built_at": 1784185517.8255181,
   "source_sitemap_size": 86,
   "pages_parsed": 86,
   "parse_errors": [],
@@ -650,6 +650,80 @@
       "reason": "Not a traditional VIP Indirect contract, so migration is currently not supported.",
       "endpoint": null,
       "response": null,
+      "docs_path": "/vipmp/docs/references/error-handling"
+    }
+  ],
+  "status_codes": [
+    {
+      "code": "1000",
+      "description": "Resource Status: Green\nAccount - Active\nOrder - Complete/Filled\nSubscription - Active",
+      "applicable_resources": "Reseller Account, Customer Account, Order, Subscription, Transfer, Deployment",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1002",
+      "description": "Resource Status: Yellow\nAccount - Pending\nOrder - Open\nSubscription - Pending",
+      "applicable_resources": "Reseller Account, Customer Account, Order, Subscription, Transfer",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1004",
+      "description": "Resource Status: Red\nAccount - Inactive\nOrder - Failed\nSubscription - Inactive\nIf there is another status code that describes the status better, that code will be used instead.",
+      "applicable_resources": "Reseller Account, Customer Account, Order, Subscription, Transfer, Deployment",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1008",
+      "description": "Order Status: Cancelled",
+      "applicable_resources": "Order",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1009",
+      "description": "Subscription Status: Scheduled",
+      "applicable_resources": "Subscription",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1010",
+      "description": "Account Status: Inactive\nReason: Invalid Address",
+      "applicable_resources": "Reseller Account, Customer Account",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1012",
+      "description": "Account Status: Inactive\nReason: Account is blocked",
+      "applicable_resources": "Reseller Account, Customer Account",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1014",
+      "description": "Account Status: Inactive\nReason: Customer already exists with the same Company Name and primary admin",
+      "applicable_resources": "Customer Account",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1020",
+      "description": "Order Status: Failed",
+      "applicable_resources": "Reason: Distributor is inactive",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1022",
+      "description": "Order Status: Failed\nReason: Reseller is inactive",
+      "applicable_resources": "Order",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1024",
+      "description": "Order Status: Failed\nReason: Customer is inactive",
+      "applicable_resources": "Order",
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "1026",
+      "description": "Order Status: Failed\nReason: Customer ID is invalid",
+      "applicable_resources": "Order",
       "docs_path": "/vipmp/docs/references/error-handling"
     }
   ],

--- a/src/vipmp_docs_mcp/extractors.py
+++ b/src/vipmp_docs_mcp/extractors.py
@@ -276,6 +276,93 @@ def extract_error_codes(html: str, docs_path: str | None = None) -> list[ErrorCo
 
 
 # ---------------------------------------------------------------------------
+# Status codes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StatusCode:
+    code: str  # "1000"
+    description: str  # "Resource Status: Green — Account - Active ..."
+    applicable_resources: str | None = None  # "Reseller Account, Customer Account, ..."
+    docs_path: str | None = None  # where this was documented
+
+    def to_dict(self) -> dict:
+        return {
+            "code": self.code,
+            "description": self.description,
+            "applicable_resources": self.applicable_resources,
+            "docs_path": self.docs_path,
+        }
+
+
+# Known typos in Adobe's published status-code table, applied to the
+# "Applicable Resources" cell. Adobe drops the comma between "Subscription"
+# and "Transfer" for codes 1000 and 1002, conflating two distinct resources
+# into a nonexistent "Subscription Transfer" (row 1004 lists them correctly).
+# Corrected here so the fix survives index rebuilds instead of being a manual
+# edit to index.json that the next refresh would overwrite.
+_APPLICABLE_RESOURCE_CORRECTIONS: tuple[tuple[str, str], ...] = (
+    ("Subscription Transfer", "Subscription, Transfer"),
+)
+
+
+def _correct_applicable_resources(value: str) -> str:
+    """Apply known source corrections to an Applicable Resources cell."""
+    for wrong, right in _APPLICABLE_RESOURCE_CORRECTIONS:
+        value = value.replace(wrong, right)
+    return value
+
+
+def extract_status_codes(html: str, docs_path: str | None = None) -> list[StatusCode]:
+    """
+    Find status-code tables on a page.
+
+    These sit at the top of the error-handling reference and describe
+    resource lifecycle states (codes 1000-1026), as opposed to the
+    request-failure error codes lower down the same page. The table shape
+    is [Status Code, Description, Applicable Resources].
+
+    The `Applicable Resources` column is required: it's what distinguishes
+    this resource-lifecycle table from the per-endpoint HTTP status-code
+    tables (200/400/404/...) scattered across the docs, which share the
+    `Status Code`/`Description` headers but carry no resource column.
+
+    Args:
+        html: Pre-fetched page HTML.
+        docs_path: Optional docs path recorded on each extracted code.
+
+    Returns:
+        Every resource status code found, in document order.
+    """
+    codes: list[StatusCode] = []
+    for headers, rows in _find_tables(html):
+        header_lower = [h.lower() for h in headers]
+        if "status code" not in header_lower or "applicable resources" not in header_lower:
+            continue
+        code_idx = header_lower.index("status code")
+        desc_idx = (
+            header_lower.index("description") if "description" in header_lower else None
+        )
+        res_idx = header_lower.index("applicable resources")
+        for row in rows:
+            needed = max(code_idx, desc_idx if desc_idx is not None else 0, res_idx)
+            if len(row) <= needed:
+                continue
+            codes.append(
+                StatusCode(
+                    code=row[code_idx].strip(),
+                    description=row[desc_idx].strip() if desc_idx is not None else "",
+                    applicable_resources=_correct_applicable_resources(
+                        row[res_idx].strip()
+                    ),
+                    docs_path=docs_path,
+                )
+            )
+    return codes
+
+
+# ---------------------------------------------------------------------------
 # Field schemas
 # ---------------------------------------------------------------------------
 

--- a/src/vipmp_docs_mcp/index.py
+++ b/src/vipmp_docs_mcp/index.py
@@ -27,10 +27,12 @@ from .extractors import (
     Endpoint,
     ErrorCode,
     SchemaResource,
+    StatusCode,
     ValidationRule,
     extract_endpoints,
     extract_error_codes,
     extract_schemas,
+    extract_status_codes,
     extract_validations,
 )
 from .fetcher import FetchError, fetch_page_html
@@ -45,7 +47,7 @@ from .releases import (
 
 log = get_logger("index")
 
-INDEX_SCHEMA_VERSION = 4  # v4 added `validations` (Adobe-published regex rules per field).
+INDEX_SCHEMA_VERSION = 5  # v5 added `status_codes` (resource lifecycle states, 1000-1026).
 
 # Per-user refresh: written by rebuild_vipmp_index tool / GHA artifact drop.
 USER_INDEX_PATH = CACHE_DIR / "index.json"
@@ -66,6 +68,7 @@ class IndexSnapshot:
     parse_errors: list[tuple[str, str]] = field(default_factory=list)
     endpoints: list[Endpoint] = field(default_factory=list)
     error_codes: list[ErrorCode] = field(default_factory=list)
+    status_codes: list[StatusCode] = field(default_factory=list)
     schemas: list[SchemaResource] = field(default_factory=list)
     releases: list[ReleaseEntry] = field(default_factory=list)
     validations: list[ValidationRule] = field(default_factory=list)
@@ -81,6 +84,7 @@ class IndexSnapshot:
             ],
             "endpoints": [e.to_dict() for e in self.endpoints],
             "error_codes": [e.to_dict() for e in self.error_codes],
+            "status_codes": [s.to_dict() for s in self.status_codes],
             "schemas": [s.to_dict() for s in self.schemas],
             "releases": [r.to_dict() for r in self.releases],
             "validations": [v.to_dict() for v in self.validations],
@@ -98,6 +102,7 @@ class IndexSnapshot:
             ],
             endpoints=[Endpoint(**e) for e in data.get("endpoints", [])],
             error_codes=[ErrorCode(**e) for e in data.get("error_codes", [])],
+            status_codes=[StatusCode(**s) for s in data.get("status_codes", [])],
             schemas=[
                 SchemaResource(
                     name=s["name"],
@@ -181,6 +186,7 @@ def build_index() -> IndexSnapshot:
         try:
             snap.endpoints.extend(extract_endpoints(html, path, title))
             snap.error_codes.extend(extract_error_codes(html, docs_path=path))
+            snap.status_codes.extend(extract_status_codes(html, docs_path=path))
             snap.schemas.extend(extract_schemas(html, docs_path=path))
             # Validations live exclusively on the references/validations page,
             # but extracting unconditionally is cheap (no-op if not the right
@@ -207,11 +213,13 @@ def build_index() -> IndexSnapshot:
             snap.parse_errors.append((path, str(exc)))
 
     log.info(
-        "built index: %d pages parsed, %d errors, %d endpoints, %d error codes, %d schemas, %d releases",
+        "built index: %d pages parsed, %d errors, %d endpoints, "
+        "%d error codes, %d status codes, %d schemas, %d releases",
         snap.pages_parsed,
         len(snap.parse_errors),
         len(snap.endpoints),
         len(snap.error_codes),
+        len(snap.status_codes),
         len(snap.schemas),
         len(snap.releases),
     )

--- a/src/vipmp_docs_mcp/remote_index.py
+++ b/src/vipmp_docs_mcp/remote_index.py
@@ -67,6 +67,7 @@ _FETCH_TIMEOUT = httpx.Timeout(10.0, connect=5.0)
 # of fake endpoints can't be detected without an authenticated source.
 MIN_ENDPOINTS = 10
 MIN_ERROR_CODES = 20
+MIN_STATUS_CODES = 8
 MIN_SCHEMAS = 5
 
 
@@ -92,6 +93,7 @@ def _check_invariants(data: dict) -> None:
     for key, floor in (
         ("endpoints", MIN_ENDPOINTS),
         ("error_codes", MIN_ERROR_CODES),
+        ("status_codes", MIN_STATUS_CODES),
         ("schemas", MIN_SCHEMAS),
     ):
         value = data.get(key)

--- a/src/vipmp_docs_mcp/server.py
+++ b/src/vipmp_docs_mcp/server.py
@@ -21,6 +21,7 @@ from .extractors import (
     extract_endpoints,
     extract_error_codes,
     extract_schemas,
+    extract_status_codes,
 )
 from .fetcher import FetchError
 from .index import (
@@ -576,6 +577,80 @@ def list_vipmp_error_codes(query: str | None = None) -> str:
 
 
 @mcp.tool(
+    title="List VIPMP status codes",
+    annotations=ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+def list_vipmp_status_codes(query: str | None = None) -> str:
+    """
+    Extract every resource status code documented across VIPMP docs
+    (numeric codes 1000-1026). These describe the lifecycle state of a
+    resource — e.g. account, order, or subscription status — as opposed
+    to the request-failure error codes surfaced by
+    `list_vipmp_error_codes`.
+
+    Args:
+        query: Optional substring filter. Matches against code,
+            description, or applicable resources. Case-insensitive.
+
+    Served from the pre-built index when available, falling back to live
+    extraction if not. Call `rebuild_vipmp_index` to refresh locally.
+    """
+    idx = get_active_index()
+    if idx is not None:
+        codes = list(idx.status_codes)
+    else:
+        codes = []
+        for docs_path, _title, html in _iter_pages():
+            codes.extend(extract_status_codes(html, docs_path=docs_path))
+
+    if query:
+        needle = query.lower()
+        codes = [
+            c
+            for c in codes
+            if needle in c.code.lower()
+            or needle in c.description.lower()
+            or (c.applicable_resources and needle in c.applicable_resources.lower())
+        ]
+
+    if not codes:
+        if query:
+            return (
+                f"_(No status codes matched query={query!r}.)_\n\n"
+                "Try:\n"
+                "- Calling `list_vipmp_status_codes` without a query to see "
+                "everything documented.\n"
+                "- A substring match — e.g. `'1000'`, `'active'`, `'order'`.\n"
+                "- `rebuild_vipmp_index` if you think the index is stale."
+            )
+        return (
+            "_(No status codes in the index.)_\n\n"
+            "Run `rebuild_vipmp_index` to populate from live Adobe docs."
+        )
+
+    codes.sort(key=lambda c: (c.code, c.docs_path or ""))
+    out = [
+        f"# VIPMP Status Codes ({len(codes)} shown"
+        + (f", query={query!r}" if query else "")
+        + ")\n",
+        _index_source_note(),
+        "",
+    ]
+    for c in codes:
+        description = c.description.replace("\n", "  \n  ")
+        out.append(f"- **{c.code}**\n  {description}")
+        if c.applicable_resources:
+            out.append(f"  _applies to:_ {c.applicable_resources}")
+        out.append(f"  _source:_ `{c.docs_path}`")
+    return "\n".join(out)
+
+
+@mcp.tool(
     title="Get VIPMP resource schema",
     annotations=ToolAnnotations(
         readOnlyHint=True,
@@ -703,8 +778,8 @@ def get_vipmp_code_examples(docs_path: str, language: str | None = None) -> str:
 )
 def rebuild_vipmp_index() -> str:
     """
-    Rebuild the pre-extracted index of endpoints, error codes, and schemas
-    by walking every page in the current sitemap. Saves to
+    Rebuild the pre-extracted index of endpoints, error codes, status
+    codes, and schemas by walking every page in the current sitemap. Saves to
     `~/.cache/swo-adobe-vipm-docs-mcp/index.json`.
 
     Run this if:
@@ -724,6 +799,7 @@ def rebuild_vipmp_index() -> str:
         f"- **Pages parsed:** {snap.pages_parsed} / {snap.source_sitemap_size}",
         f"- **Endpoints extracted:** {len(snap.endpoints)}",
         f"- **Error codes extracted:** {len(snap.error_codes)}",
+        f"- **Status codes extracted:** {len(snap.status_codes)}",
         f"- **Schemas extracted:** {len(snap.schemas)}",
         f"- **Parse errors:** {len(snap.parse_errors)}",
         f"- **Saved to:** `{USER_INDEX_PATH}`",
@@ -1025,6 +1101,7 @@ def vipmp_server_info() -> str:
             f"{len(idx.endpoints)} endpoints "
             f"({sum(1 for e in idx.endpoints if e.deprecated)} deprecated), "
             f"{len(idx.error_codes)} error codes, "
+            f"{len(idx.status_codes)} status codes, "
             f"{len(idx.schemas)} schemas, "
             f"{len(idx.releases)} releases — "
             f"built {idx.age_seconds / 3600:.1f}h ago"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,50 @@ def error_codes_html() -> str:
 
 
 @pytest.fixture
+def status_codes_html() -> str:
+    """Minimal synthetic HTML matching Adobe's status-codes-table shape."""
+    return """
+<html><body>
+<main>
+<h1>Error Handling</h1>
+
+<div class="table">
+  <div>
+    <div>Status Code</div>
+    <div>Description</div>
+    <div>Applicable Resources</div>
+  </div>
+  <div>
+    <div>1000</div>
+    <div>Resource Status: Green&lt;br /&gt;Account - Active</div>
+    <div>Reseller Account, Customer Account, Order</div>
+  </div>
+  <div>
+    <div>1008</div>
+    <div>Order Status: Cancelled</div>
+    <div>Order</div>
+  </div>
+</div>
+
+<h2 id="error-codes">Error Codes</h2>
+<div class="table">
+  <div>
+    <div>Error Code</div>
+    <div>Reason</div>
+  </div>
+  <div>
+    <div>1114</div>
+    <div>Invalid Distributor</div>
+  </div>
+</div>
+
+<p>vipmp marker</p>
+</main>
+</body></html>
+"""
+
+
+@pytest.fixture
 def resources_html() -> str:
     """Minimal synthetic HTML matching Adobe's resources-page shape."""
     return """

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -7,6 +7,7 @@ from vipmp_docs_mcp.extractors import (
     extract_endpoints,
     extract_error_codes,
     extract_schemas,
+    extract_status_codes,
 )
 
 
@@ -48,6 +49,62 @@ class TestExtractErrorCodes:
 
     def test_no_table_returns_empty(self, flat_page_html: str):
         assert extract_error_codes(flat_page_html) == []
+
+
+class TestExtractStatusCodes:
+    def test_finds_status_codes(self, status_codes_html: str):
+        codes = extract_status_codes(status_codes_html, docs_path="/vipmp/docs/references/error-handling")
+        assert {c.code for c in codes} == {"1000", "1008"}
+
+    def test_description_captured(self, status_codes_html: str):
+        codes = extract_status_codes(status_codes_html)
+        code_1000 = next(c for c in codes if c.code == "1000")
+        assert "Green" in code_1000.description
+        assert "Active" in code_1000.description
+
+    def test_applicable_resources_captured(self, status_codes_html: str):
+        codes = extract_status_codes(status_codes_html)
+        code_1000 = next(c for c in codes if c.code == "1000")
+        assert "Customer Account" in (code_1000.applicable_resources or "")
+
+    def test_docs_path_recorded(self, status_codes_html: str):
+        codes = extract_status_codes(status_codes_html, docs_path="/x")
+        assert all(c.docs_path == "/x" for c in codes)
+
+    def test_error_code_table_ignored(self, status_codes_html: str):
+        codes = extract_status_codes(status_codes_html)
+        assert "1114" not in {c.code for c in codes}
+
+    def test_subscription_transfer_typo_corrected(self):
+        # Adobe's page drops the comma between "Subscription" and "Transfer"
+        # for codes 1000/1002; the extractor corrects it to two resources.
+        html = """
+<html><body><main>
+<div class="table">
+  <div><div>Status Code</div><div>Description</div><div>Applicable Resources</div></div>
+  <div><div>1000</div><div>Green</div><div>Order, Subscription Transfer, Deployment</div></div>
+</div>
+</main></body></html>
+"""
+        code = extract_status_codes(html)[0]
+        assert code.applicable_resources == "Order, Subscription, Transfer, Deployment"
+
+    def test_http_status_table_ignored(self):
+        # Per-endpoint HTTP status tables share the Status Code/Description
+        # headers but have no Applicable Resources column — must be skipped.
+        html = """
+<html><body><main>
+<div class="table">
+  <div><div>Status code</div><div>Description</div></div>
+  <div><div>200</div><div>OK</div></div>
+  <div><div>400</div><div>Bad request</div></div>
+</div>
+</main></body></html>
+"""
+        assert extract_status_codes(html) == []
+
+    def test_no_table_returns_empty(self, flat_page_html: str):
+        assert extract_status_codes(flat_page_html) == []
 
 
 class TestExtractSchemas:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -10,7 +10,13 @@ import pytest
 
 from vipmp_docs_mcp import index as index_module
 from vipmp_docs_mcp import remote_index
-from vipmp_docs_mcp.extractors import Endpoint, ErrorCode, SchemaField, SchemaResource
+from vipmp_docs_mcp.extractors import (
+    Endpoint,
+    ErrorCode,
+    SchemaField,
+    SchemaResource,
+    StatusCode,
+)
 from vipmp_docs_mcp.index import (
     INDEX_SCHEMA_VERSION,
     IndexSnapshot,
@@ -33,6 +39,13 @@ def _sample_snap() -> IndexSnapshot:
         ],
         error_codes=[
             ErrorCode(code="1117", reason="bad date", endpoint="POST /v3/customers"),
+        ],
+        status_codes=[
+            StatusCode(
+                code="1000",
+                description="Resource Status: Green",
+                applicable_resources="Customer Account",
+            ),
         ],
         schemas=[
             SchemaResource(
@@ -69,6 +82,9 @@ class TestRoundtrip:
         assert loaded.endpoints[0].path == "/v3/customers"
         assert len(loaded.error_codes) == 1
         assert loaded.error_codes[0].code == "1117"
+        assert len(loaded.status_codes) == 1
+        assert loaded.status_codes[0].code == "1000"
+        assert loaded.status_codes[0].applicable_resources == "Customer Account"
         assert len(loaded.schemas) == 1
         assert loaded.schemas[0].name == "Customer"
         assert loaded.schemas[0].fields[0].name == "id"

--- a/tests/test_remote_index.py
+++ b/tests/test_remote_index.py
@@ -39,6 +39,7 @@ def _valid_index_body() -> bytes:
         MIN_ENDPOINTS,
         MIN_ERROR_CODES,
         MIN_SCHEMAS,
+        MIN_STATUS_CODES,
     )
 
     return json.dumps(
@@ -46,6 +47,7 @@ def _valid_index_body() -> bytes:
             "schema_version": INDEX_SCHEMA_VERSION,
             "endpoints": [{} for _ in range(MIN_ENDPOINTS)],
             "error_codes": [{} for _ in range(MIN_ERROR_CODES)],
+            "status_codes": [{} for _ in range(MIN_STATUS_CODES)],
             "schemas": [{} for _ in range(MIN_SCHEMAS)],
         }
     ).encode()


### PR DESCRIPTION
## Summary

Adds a new MCP tool, **`list_vipmp_status_codes`**, mirroring `list_vipmp_error_codes`. It surfaces the resource-lifecycle status codes (1000–1026) documented at the top of the [error-handling reference page](https://developer.adobe.com/vipmp/docs/references/error-handling) — the states a resource (account/order/subscription) can be in, as distinct from request-failure error codes.

## Changes

- **Extraction** (`extractors.py`): new `StatusCode` dataclass and `extract_status_codes()`. Scoped to tables carrying **both** `Status Code` **and** `Applicable Resources` headers. This guard matters — the bare `Status Code`/`Description` header also appears on ~30 per-endpoint pages listing HTTP codes (200/400/404…); without it the index pulled in **221** entries instead of the **12** lifecycle codes.
- **Source typo correction**: Adobe's page lists `"Subscription Transfer"` for codes 1000/1002 where it should be `"Subscription, Transfer"` (row 1004 lists them correctly as two resources). Corrected in the extractor so the fix survives index rebuilds — a manual `index.json` edit would be overwritten by the weekly refresh.
- **Index** (`index.py`): added `status_codes` to the snapshot (to_dict/from_dict/build), bumped `INDEX_SCHEMA_VERSION` 4→5, and rebuilt the shipped baseline `data/index.json`. The bump means stale v4 indexes (including cached remote ones) are ignored until CI republishes v5.
- **Guardrails**: `MIN_STATUS_CODES = 8` invariant in `remote_index.py`, plus build-stats / validation-floor / PR-body wiring in `refresh-index.yml`, so a parser regression to empty is caught.

## Testing

- Extractor tests: extraction, description/resources capture, HTTP-table exclusion, typo correction.
- Index round-trip and remote-index invariant fixture updated.
- Full suite: **207 passed**, `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)