### PR TITLE
chore(release): bump version to 0.12.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "vipmp-docs-mcp",
   "display_name": "Adobe VIP Marketplace Docs",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
   "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes — without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.11.0"
+version = "0.12.0"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Manual version bump to **0.12.0** in `pyproject.toml` and `manifest.json`.

Ships this cycle's merged work:
- `list_vipmp_status_codes` tool — resource lifecycle status codes 1000–1026 (#22)
- Repo-wide `ruff format` + CI format gate (#23)
- CODEOWNERS (#24)
- CodeQL security/quality scanning (#25)

## Release process

Once this merges, I'll tag the merge commit **`v0.12.0`** (after CI goes green on it), which triggers `publish-pypi.yml` (PyPI via OIDC) and `publish-mcpb.yml` (GitHub Release + `.mcpb` bundle). Both re-verify CI passed on the tagged commit before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)