### PR TITLE
chore(data): refresh sitemap + structured index from Adobe docs

### DIFF
--- a/src/vipmp_docs_mcp/data/index.json
+++ b/src/vipmp_docs_mcp/data/index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 5,
-  "built_at": 1784185517.8255181,
+  "built_at": 1785130607.4569862,
   "source_sitemap_size": 86,
   "pages_parsed": 86,
   "parse_errors": [],
@@ -385,6 +385,27 @@
       "endpoint": null,
       "response": null,
       "docs_path": "/vipmp/docs/lga/error-codes"
+    },
+    {
+      "code": "SWITCH_ORDER_CANCELLATION_NOT_ALLOWED",
+      "reason": "Referenced order is a SWITCH order. Partial quantity returns are not supported for Switch Plan orders.",
+      "endpoint": null,
+      "response": null,
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "THREE_YEAR_COMMIT",
+      "reason": "Return would reduce the committed product-family quantity below the minimum commit quantity",
+      "endpoint": null,
+      "response": null,
+      "docs_path": "/vipmp/docs/references/error-handling"
+    },
+    {
+      "code": "PARTIAL_CANCELLATION_NOT_ALLOWED_FOR_SCP_OR_CONSUMABLE",
+      "reason": "Partial quantity returns are not supported for Switch Plan orders, Stock Credit Packs, Acrobat license packs, MOQ offers, or consumables such as Sign transactions.",
+      "endpoint": null,
+      "response": null,
+      "docs_path": "/vipmp/docs/references/error-handling"
     },
     {
       "code": "INELIGIBLE_SWITCH",
@@ -1491,6 +1512,14 @@
           "deprecated": false
         },
         {
+          "name": "remainingQuantity",
+          "type": "Integer",
+          "required": null,
+          "description": "The quantity available after the returns and mid-term switch plan cancellations against the same line item.",
+          "constraints": null,
+          "deprecated": false
+        },
+        {
           "name": "flexDiscounts",
           "type": "Object",
           "required": null,
@@ -2171,7 +2200,7 @@
       "changes": [
         {
           "title": "Upcoming changes",
-          "body": "Churn and seat expansion propensity are now surfaced in the Recommendations API\n\nExpected release: July 2026\n\nPartners can now see churn risk and seat expansion signals for each customer through the existing Fetch Recommendations ( POST /v3/recommendations ) API.\n\nWhat changed?\n\nSetting the request parameter includePropensity to true fetches churn and seatExpansion arrays. Each contains a probability rating ( HIGH , MEDIUM , or LOW ), a refreshDate , and a reasons array with up to seven leading indicators ordered by relevance.\n\nSeat expansion also includes predictedAddonSize with the expected number of additional seats.\n\nImportant: An empty object {} for either node means propensity data is not available for that customer. Do not interpret {} as LOW risk or LOW expansion potential.\n\nWhy it matters\n\nPartners can now identify at-risk customers and high-growth opportunities using data-driven signals, rather than relying on anecdotal indicators or waiting for account-manager outreach.\n\nAction required\n\nFor more information, see Propensity Intelligence .\n\nTesting Propensity Signals in sandbox\n\nA set of 13 predefined test seeds is configured in the Sandbox so you can exercise every combination of rating level and empty-array behavior during integration testing. Each seed returns a fixed response.\n\nFor more information, see Testing Propensity Signals in sandbox ."
+          "body": "Partial quantity returns for VIP Marketplace orders\n\nExpected release: August, 2026\n\nPartners can now return a portion of an eligible line item quantity from a NEW or RENEWAL order within 14 days of the order date. Previously, partners could return only the entire line item quantity in a single request.\n\nWhat changed?\n\nThe following enhancements support partial quantity returns for eligible orders:\n\n- The newly introduced remainingQuantity parameter on the Order resource indicates the quantity that is still available for return in NEW and RENEWAL orders. The Get Order Details and Get Order History APIs return this parameter. The value is initially set to the line item's quantity and decreases after each return or mid-term Switch Plan cancellation associated with that line item.\n\n- You can now submit a return request for any quantity that is less than or equal to the line item's remainingQuantity . The request and response schemas of a RETURN order remains unchanged.\n\n- You can submit multiple partial returns against the same line item. Each return request is validated against the line item's current remainingQuantity .\n\n- Partial quantity returns are not supported for Switch Plan orders, Stock Credit Packs, Acrobat license packs, MOQ offers, or consumables such as Sign transactions.\n\n- Licenses associated with a returned quantity are deprovisioned immediately after the return order is completed.\n\nFor complete request and response examples and a list of supported error codes, see Return or cancellation of order .\n\nWhy it matters\n\nPreviously, when a customer needed fewer licenses than originally ordered, partners had to return the entire line item and place a new order for the correct quantity. This process could result in a revenue gap of 1 to 14 days between the full-term billed return and the day-billed replacement order.\n\nWith partial quantity returns, partners can return only the quantity that the customer no longer requires through a single request, eliminating the need to create a replacement order.\n\nAction required\n\nReview the following updates to ensure that your integration supports partial quantity returns:\n\nSandbox changes\n\nThe Order details also display the remaining quantity available for return. For more information, see Cancel an order in Sandbox .\n\nChurn and seat expansion propensity are now surfaced in the Recommendations API\n\nExpected release: August 2026\n\nPartners can now see churn risk and seat expansion signals for each customer through the existing Fetch Recommendations ( POST /v3/recommendations ) API.\n\nWhat changed?\n\nSetting the request parameter includePropensity to true fetches churn and seatExpansion arrays. Each contains a probability rating ( HIGH , MEDIUM , or LOW ), a refreshDate , and a reasons array with up to seven leading indicators ordered by relevance.\n\nSeat expansion also includes predictedAddonSize with the expected number of additional seats.\n\nImportant: An empty object {} for either node means propensity data is not available for that customer. Do not interpret {} as LOW risk or LOW expansion potential.\n\nWhy it matters\n\nPartners can now identify at-risk customers and high-growth opportunities using data-driven signals, rather than relying on anecdotal indicators or waiting for account-manager outreach.\n\nAction required\n\nFor more information, see Propensity Intelligence .\n\nTesting Propensity Signals in sandbox\n\nA set of 13 predefined test seeds is configured in the Sandbox so you can exercise every combination of rating level and empty-array behavior during integration testing. Each seed returns a fixed response.\n\nFor more information, see Testing Propensity Signals in sandbox ."
         }
       ],
       "docs_path": "/vipmp/docs/release-notes/upcoming-releases"

--- a/src/vipmp_docs_mcp/data/sitemap.json
+++ b/src/vipmp_docs_mcp/data/sitemap.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": 1782366425.7081997,
+  "generated_at": 1785130600.3092375,
   "entries": [
     {
       "path": "/vipmp/docs",


### PR DESCRIPTION
Automated refresh of `src/vipmp_docs_mcp/data/sitemap.json` and `src/vipmp_docs_mcp/data/index.json` from live Adobe docs.

**Trigger:** scheduled (weekly)

## Build stats

| | |
|---|---|
| Sitemap size | 86 |
| Pages parsed | 86 |
| Endpoints | 22 |
| Error codes | 70 |
| Status codes | 12 |
| Schemas | 18 |
| Parse errors | 0 |
| Sitemap build time | 10.5s |
| Index build time | 12.1s |

## Parse errors (if any)

See the workflow run artifact and/or the diff.

## What to check before merging

- Large changes in **endpoints** / **error_codes** / **schemas** counts — could mean Adobe restructured, or our parser regressed.
- Any **parse_errors** entries — new pages we can't parse.
- Spot-check the JSON diff for obvious junk (empty strings, stray HTML leaking through, etc.).

Downstream installs (`pip install -e .`, `uvx --from git+...`) pick up the new baseline on the next cache refresh, and the v0.7.0+ github-remote tier now fetches it within 12 h without a PyPI release.

---

🤖 Generated by [`.github/workflows/refresh-index.yml`](.github/workflows/refresh-index.yml) — auto-merged once CI passes.