### PR TITLE
fix: declare list_vipmp_status_codes in manifest.json (0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] — 2026-07-27
+
+### Fixed
+- **`list_vipmp_status_codes` is now declared in `manifest.json`.** The tool
+  shipped in 0.12.0 but was never added to the manifest's `tools` array, which
+  is what MCP clients reading the bundle metadata — Claude Desktop among them —
+  display as the extension's tool set. The server advertised the tool correctly
+  over `tools/list`, so clients that enumerate tools dynamically (Claude Code,
+  the `examples/list_tools.py` script) were unaffected; Desktop users simply
+  never saw it.
+
+### Added
+- **Manifest parity tests** (`tests/test_manifest.py`). CI now fails if
+  `manifest.json` omits a tool the server registers, declares one it doesn't,
+  ships a tool without a description, or drifts out of version sync with
+  `pyproject.toml`. This is the check whose absence let the above go unnoticed
+  for two releases.
+- **`list_vipmp_status_codes` documented in the README** — added to the
+  structured-extractors table and to the list of index-served tools.
+
+> **Note:** releases 0.10.0 through 0.13.0 predate this entry and are not
+> recorded here; the changelog was not kept up to date across those bumps.
+
 ## [0.9.0] — 2026-05-03
 
 ### Security / hardening (response to external code review)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Claude calls one of the tools below, the server fetches and parses the relevant 
 |---|---|
 | `list_vipmp_endpoints()` | Every REST endpoint across the docs — method + path + source page. |
 | `list_vipmp_error_codes(query?)` | Every documented error code (numeric + symbolic) with triggering endpoint and reason. |
+| `list_vipmp_status_codes(query?)` | Every documented **resource lifecycle** status code (1000–1026) with its applicable resources — the state a customer, order, or subscription is in, as opposed to the request-failure codes above. |
 | `get_vipmp_schema(resource_name?)` | Structured field schemas (name, type, required, description, constraints) for VIPMP resources. |
 | `get_vipmp_code_examples(docs_path, language?)` | Pull JSON / curl / Python / etc. code blocks off a specific page. |
 | `list_vipmp_releases(since?, section?, limit?)` | **Dated release entries** — API changes, Sandbox changes, and upcoming. Filter by date or section. Refreshed daily. See [Tracking releases](#tracking-releases) below. |
@@ -256,7 +257,7 @@ Sections are kept separate because they mean different things: `api_changes` is 
 
 ## The structured index
 
-The `list_vipmp_endpoints`, `list_vipmp_error_codes`, `get_vipmp_schema`, and `get_vipmp_releases` tools are all served from a **pre-built index** — a single JSON file that captures every endpoint, error code, and field schema extracted from Adobe's docs. With the index in place these tools answer in **single-digit milliseconds**. Without it, they fall back to live extraction across ~86 pages (~30s cold, ~5s warm).
+The `list_vipmp_endpoints`, `list_vipmp_error_codes`, `list_vipmp_status_codes`, `get_vipmp_schema`, and `get_vipmp_releases` tools are all served from a **pre-built index** — a single JSON file that captures every endpoint, error code, status code, and field schema extracted from Adobe's docs. With the index in place these tools answer in **single-digit milliseconds**. Without it, they fall back to live extraction across ~86 pages (~30s cold, ~5s warm).
 
 **Three-tier resolution for the active index:**
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "vipmp-docs-mcp",
   "display_name": "Adobe VIP Marketplace Docs",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
   "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes \u2014 without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
   "author": {
@@ -85,6 +85,10 @@
     {
       "name": "list_vipmp_error_codes",
       "description": "List all numeric and symbolic error codes with triggers."
+    },
+    {
+      "name": "list_vipmp_status_codes",
+      "description": "List resource lifecycle status codes (1000-1026) with applicable resources."
     },
     {
       "name": "get_vipmp_schema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.13.0"
+version = "0.13.1"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,72 @@
+"""
+Tests that keep manifest.json honest about what the server exposes.
+
+The manifest's `tools` array is what MCP clients that read the bundle
+metadata — Claude Desktop among them — display as the extension's tool
+set. It is hand-maintained, so it silently drifts whenever a tool is
+added to server.py and the manifest is forgotten. That happened with
+`list_vipmp_status_codes` (added in 0.12.0, absent from the manifest
+until 0.13.1): the server advertised it over `tools/list`, but Desktop
+never showed it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "manifest.json"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _registered_tool_names() -> set[str]:
+    """Names of every tool the FastMCP server actually registers."""
+    from vipmp_docs_mcp.server import mcp
+
+    return {tool.name for tool in asyncio.run(mcp.list_tools())}
+
+
+class TestManifestToolParity:
+    """
+    The manifest must list exactly the tools the server registers —
+    no missing entries (invisible in clients that read the manifest)
+    and no stale ones (advertised but uncallable).
+    """
+
+    def test_manifest_lists_every_registered_tool(self):
+        declared = {t["name"] for t in _manifest()["tools"]}
+        missing = _registered_tool_names() - declared
+        assert not missing, (
+            f"tools registered in server.py but absent from manifest.json: {sorted(missing)}"
+        )
+
+    def test_manifest_declares_no_unknown_tools(self):
+        declared = {t["name"] for t in _manifest()["tools"]}
+        stale = declared - _registered_tool_names()
+        assert not stale, (
+            f"tools declared in manifest.json but not registered in server.py: {sorted(stale)}"
+        )
+
+    def test_every_declared_tool_has_a_description(self):
+        for tool in _manifest()["tools"]:
+            description = tool.get("description", "")
+            assert description.strip(), f"{tool['name']} has no description in manifest.json"
+
+
+class TestManifestVersion:
+    """
+    manifest.json and pyproject.toml are bumped together by
+    auto-version-bump.yml. A mismatch means a release published a
+    bundle whose advertised version disagrees with the wheel.
+    """
+
+    def test_manifest_version_matches_pyproject(self):
+        pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+        assert _manifest()["version"] == pyproject["project"]["version"]


### PR DESCRIPTION
## Problem

`list_vipmp_status_codes` shipped in **0.12.0** (commit 2e5cdd8), but that commit never touched `manifest.json`. The manifest's `tools` array listed **19** of the server's **20** tools.

MCP clients that read the bundle metadata instead of calling `tools/list` — Claude Desktop among them — therefore presented the extension without the tool. Clients that enumerate dynamically (Claude Code, `examples/list_tools.py`) were unaffected, which is why this survived two releases unnoticed.

## Changes

- **`manifest.json`** — declare `list_vipmp_status_codes` alongside `list_vipmp_error_codes`.
- **`tests/test_manifest.py`** (new) — manifest/server parity. Fails if the manifest omits a registered tool, declares one the server doesn't register, ships a tool with an empty description, or drifts out of version sync with `pyproject.toml`. This is the check whose absence allowed the drift.
- **`README.md`** — document the tool in the structured-extractors table and add it to the list of index-served tools, spelling out the resource-lifecycle vs request-failure distinction against `list_vipmp_error_codes`.
- **`CHANGELOG.md`** / **`pyproject.toml`** / **`manifest.json`** — record the fix and bump to **0.13.1**.

## Verification

- Full suite: **211 passed**.
- `ruff check` and `ruff format --check` clean over `src/` + `tests/` (CI's scope).
- Confirmed the new test reproduces the original bug: reverting the manifest entry fails `test_manifest_lists_every_registered_tool` with `absent from manifest.json: ['list_vipmp_status_codes']`.

## Release note

`auto-version-bump.yml` only fires for `bot/`-prefixed branches and bumps the **minor** version, so it will not act on this PR. **v0.13.1 needs a manual tag** on the merge commit to trigger `publish-mcpb.yml` / `publish-pypi.yml`, which is the documented path for human-driven releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)