### PR TITLE
chore: gate ruff on scripts/examples and derive smoke-test tools from manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
           pip install -e ".[dev]"
 
       - name: Lint
-        run: ruff check src/ tests/
+        run: ruff check src/ tests/ scripts/ examples/
 
       - name: Format check
-        run: ruff format --check src/ tests/
+        run: ruff format --check src/ tests/ scripts/ examples/
 
       - name: Import check
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,10 @@ Tests live in `tests/` with synthetic HTML fixtures in `tests/conftest.py`.
 
 1. Add the function to `src/vipmp_docs_mcp/server.py` with the `@mcp.tool(...)` decorator.
 2. Always set `title` and `annotations=ToolAnnotations(...)` — see existing tools for the pattern.
-3. Add the tool name to the `expected_tools` set in `scripts/smoke_test.py` and add an assertion that exercises it.
-4. Add at least one unit test in `tests/`.
-5. Update `README.md`'s tools table.
+3. **Declare the tool in `manifest.json`'s `tools` array** (name + one-line description). This is what MCP clients that read the bundle metadata — Claude Desktop among them — display, so a tool missing here is invisible to those users even though the server serves it. `tests/test_manifest.py` fails if you skip this.
+4. Add an assertion to `scripts/smoke_test.py` that exercises the tool. You do **not** need to register the name there — the expected set is derived from `manifest.json`.
+5. Add at least one unit test in `tests/`.
+6. Update `README.md`'s tools table.
 
 ## Adding a new extractor
 
@@ -82,7 +83,8 @@ Tests live in `tests/` with synthetic HTML fixtures in `tests/conftest.py`.
 1. Add a function with `@mcp.prompt()` in `src/vipmp_docs_mcp/prompts.py`.
 2. Be explicit about which tools Claude should chain — prompts are only as good as their tool hints.
 3. Avoid gaps in numbered steps (the smoke test checks for this).
-4. Add a smoke-test assertion that the prompt renders correctly.
+4. Add the prompt name to `EXPECTED_PROMPTS` in `scripts/smoke_test.py`. Prompts are registered dynamically, so unlike tools there's no manifest declaration to derive the set from.
+5. Add a smoke-test assertion that the prompt renders correctly.
 
 ## Commit style
 

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -14,6 +14,7 @@ Run from the repo root with the venv active:
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "manifest.json"
 # Use the venv's console script so we pick up the editable install.
 if sys.platform == "win32":
     CONSOLE_SCRIPT = REPO_ROOT / ".venv" / "Scripts" / "vipmp-docs-mcp.exe"
@@ -38,6 +40,41 @@ def ok(msg: str) -> None:
 
 def fail(msg: str) -> None:
     print(f"  {FAIL} {msg}")
+
+
+def declared_tool_names() -> set[str]:
+    """
+    Tool names declared in ``manifest.json``.
+
+    The manifest is the contract MCP clients that read bundle metadata —
+    Claude Desktop among them — present to users, so it is the right
+    expectation to hold the running server to. Deriving the set from it
+    also means there is one place to update when a tool is added;
+    hardcoding a second copy here is what let ``list_vipmp_status_codes``
+    ship in 0.12.0 while the manifest advertised 19 of 20 tools.
+    """
+    data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return {tool["name"] for tool in data["tools"]}
+
+
+# Prompts are registered dynamically (`prompts_generated: true` in the
+# manifest, so there is no declared list to derive from). Keep this in
+# step with `register_prompts` in src/vipmp_docs_mcp/prompts.py.
+EXPECTED_PROMPTS = {
+    "review_request_body",
+    "debug_error_code",
+    "draft_order",
+    "summarize_recent_changes",
+    "check_feature_status",
+    "check_3yc_eligibility",
+    "start_vipmp_learning",
+    "learn_customer_lifecycle",
+    "learn_ordering_flow",
+    "learn_3yc",
+    "learn_subscriptions_and_renewals",
+    "learn_returns_and_refunds",
+    "learn_auth_and_sandbox",
+}
 
 
 async def main() -> int:
@@ -69,47 +106,32 @@ async def main() -> int:
         ok(f"{len(tools.tools)} tools")
         ok(f"{len(prompts.prompts)} prompts")
 
-        expected_tools = {
-            "list_vipmp_docs",
-            "search_vipmp_docs",
-            "get_vipmp_page",
-            "warm_vipmp_cache",
-            "refresh_vipmp_sitemap",
-            "rebuild_vipmp_index",
-            "vipmp_cache_stats",
-            "vipmp_cache_clear",
-            "list_vipmp_endpoints",
-            "list_vipmp_error_codes",
-            "get_vipmp_schema",
-            "get_vipmp_code_examples",
-            "list_vipmp_releases",
-            "describe_vipmp_endpoint",
-            "validate_vipmp_request",
-            "generate_vipmp_request",
-            "vipmp_server_info",
-        }
+        expected_tools = declared_tool_names()
         got_tools = {t.name for t in tools.tools}
         missing = expected_tools - got_tools
-        extra = got_tools - expected_tools
+        undeclared = got_tools - expected_tools
         if missing:
-            fail(f"missing tools: {sorted(missing)}")
+            fail(f"declared in manifest.json but not served: {sorted(missing)}")
             failures += 1
-        if extra:
-            ok(f"extra tools (new?): {sorted(extra)}")
+        if undeclared:
+            fail(
+                f"served but not declared in manifest.json: {sorted(undeclared)} "
+                "— clients that read the manifest won't show these"
+            )
+            failures += 1
+        if not missing and not undeclared:
+            ok(f"all {len(expected_tools)} manifest-declared tools served")
 
-        expected_prompts = {
-            "review_request_body",
-            "debug_error_code",
-            "draft_order",
-            "summarize_recent_changes",
-            "check_feature_status",
-            "check_3yc_eligibility",
-        }
         got_prompts = {p.name for p in prompts.prompts}
-        missing_p = expected_prompts - got_prompts
+        missing_p = EXPECTED_PROMPTS - got_prompts
+        extra_p = got_prompts - EXPECTED_PROMPTS
         if missing_p:
             fail(f"missing prompts: {sorted(missing_p)}")
             failures += 1
+        if extra_p:
+            ok(f"extra prompts (new? add to EXPECTED_PROMPTS): {sorted(extra_p)}")
+        if not missing_p and not extra_p:
+            ok(f"all {len(EXPECTED_PROMPTS)} expected prompts served")
 
         # --- Tool: list_vipmp_docs (no network) ------------------------
         print("\nlist_vipmp_docs (no network)")


### PR DESCRIPTION
The two follow-ups noted on #29. Both are instances of the same failure mode behind the 0.13.1 manifest bug: a hand-maintained list of tools with nothing keeping it honest.

## 1. CI now gates `scripts/` and `examples/`

Both ruff steps extended to `src/ tests/ scripts/ examples/`. #29 existed only because the gate covered `src/` and `tests/` while `CONTRIBUTING.md` tells contributors to run ruff over all four — so drift there was invisible to CI and visible to anyone following the docs.

## 2. Smoke test derives its expected tools from `manifest.json`

`expected_tools` was a hardcoded set of **17**, missing `list_vipmp_status_codes`, `get_vipmp_tips`, and `list_vipmp_tip_topics`. It's now derived from the manifest, giving one declared source of truth.

That closes a triangle: `tests/test_manifest.py` holds **manifest ↔ server registrations** in sync in-process, and the smoke test now verifies **manifest ↔ what the running server actually serves over stdio**.

Mismatch in either direction now **fails** and exits non-zero. Previously an undeclared tool was reported via `ok(...)` — i.e. the exact 0.13.1 condition would have passed the smoke test.

`expected_prompts` was stale the same way — **6 of 13**, missing every `learn_*` walkthrough and the `start_vipmp_learning` router. Prompts are registered dynamically (`prompts_generated: true`, no manifest declaration to derive from), so it's completed as a module-level `EXPECTED_PROMPTS` with unexpected extras now surfaced.

## 3. `CONTRIBUTING.md` — the actual root cause

The "Adding a new tool" checklist **never mentioned `manifest.json`**. That omission is why 0.12.0 shipped a tool Desktop couldn't see. Now:

- declaring the tool in the manifest is an explicit step, noting `tests/test_manifest.py` enforces it;
- the smoke-test step says you no longer register the name there, only add an assertion;
- "Adding a new prompt" gained the matching `EXPECTED_PROMPTS` step.

## Verification

- Smoke test passes end to end: `all 20 manifest-declared tools served`, `all 13 expected prompts served`.
- **Failure path verified:** removing `list_vipmp_status_codes` from the manifest produces `✗ served but not declared in manifest.json: ['list_vipmp_status_codes']` and **exit 1**. Manifest confirmed byte-identical afterwards.
- `ruff check` + `ruff format --check` clean across all four paths.
- Full suite: 211 passed.

No version bump — CI config, a dev script, and docs. Nothing in the shipped package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)