### PR TITLE
fix: resolve CodeQL quality alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Merged to main but not yet released. Nothing here changes the shipped
-package — CI config, a dev script, and docs.
+Merged to main but not yet released. No behaviour changes — CI config, a dev
+script, docs, and internal restructuring with no effect on tool output.
+
+### Fixed
+- **Resolved the `index` ↔ `remote_index` import cycle.** `INDEX_SCHEMA_VERSION`
+  lived in `index.py` but `remote_index._check_invariants` needed it, so each
+  module reached for the other through a function-local import. The constant
+  now lives in a leaf module, `index_schema.py`, letting both import it at
+  module level; `index.py`'s import of `ensure_fresh` is no longer deferred
+  either. The package's module-level import graph is now acyclic. It still
+  imports from `vipmp_docs_mcp.index`, so callers — including
+  `refresh-index.yml` — are unaffected.
+- **A prompt that raises while rendering now reports its cause.** The
+  `_rendered_prompts` test helper caught every exception and `pass`ed, so a
+  broken template surfaced as a bare "didn't render" with no traceback. Render
+  failures are now recorded against the prompt name and asserted on
+  explicitly, so the underlying error reaches the test output.
+- Removed the dead `_REGEX_ENGINE_NAME` global in `validator.py`, assigned in
+  both branches of the `regex`/`re` import fallback and never read.
+
+  > These three came from CodeQL quality alerts. A fourth,
+  > `py/ineffectual-statement` on `await maybe_aw` in `fetcher.py`, is a false
+  > positive — the await runs the `on_progress` coroutine, as
+  > `test_async_progress_callback_awaited` asserts — and is dismissed rather
+  > than worked around.
 
 ### Changed
 - **`ruff check` and `ruff format --check` now gate `scripts/` and

--- a/src/vipmp_docs_mcp/index.py
+++ b/src/vipmp_docs_mcp/index.py
@@ -36,6 +36,7 @@ from .extractors import (
     extract_validations,
 )
 from .fetcher import FetchError, fetch_page_html
+from .index_schema import INDEX_SCHEMA_VERSION
 from .logging_config import CACHE_DIR, get_logger
 from .releases import (
     RELEASE_NOTES_PATH,
@@ -44,10 +45,9 @@ from .releases import (
     parse_recent_releases,
     parse_upcoming_releases,
 )
+from .remote_index import ensure_fresh
 
 log = get_logger("index")
-
-INDEX_SCHEMA_VERSION = 5  # v5 added `status_codes` (resource lifecycle states, 1000-1026).
 
 # Per-user refresh: written by rebuild_vipmp_index tool / GHA artifact drop.
 USER_INDEX_PATH = CACHE_DIR / "index.json"
@@ -277,11 +277,6 @@ def resolve_active_index() -> ActiveIndex | None:
     if user is not None:
         log.debug("using user-local index (age=%.0fs)", user.age_seconds)
         return ActiveIndex(user, "user-local", USER_INDEX_PATH)
-
-    # Local import to avoid a circular dependency at module load time —
-    # remote_index doesn't import index, but this keeps the coupling
-    # one-way at runtime as well.
-    from .remote_index import ensure_fresh
 
     remote_path = ensure_fresh()
     if remote_path is not None:

--- a/src/vipmp_docs_mcp/index_schema.py
+++ b/src/vipmp_docs_mcp/index_schema.py
@@ -1,0 +1,16 @@
+"""
+On-disk schema version for the structured index.
+
+Kept in its own leaf module because both `index.py` (which writes and reads
+the snapshot) and `remote_index.py` (which rejects a GitHub-fetched copy
+whose version doesn't match) need it. Holding it here lets both import it
+at module level instead of reaching for each other lazily, which is what
+previously made the two modules mutually dependent.
+
+Bump this whenever the on-disk shape of the index changes, so a stale
+cached or remote copy is rejected instead of silently misread.
+"""
+
+from __future__ import annotations
+
+INDEX_SCHEMA_VERSION = 5  # v5 added `status_codes` (resource lifecycle states, 1000-1026).

--- a/src/vipmp_docs_mcp/remote_index.py
+++ b/src/vipmp_docs_mcp/remote_index.py
@@ -37,6 +37,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from .index_schema import INDEX_SCHEMA_VERSION
 from .logging_config import CACHE_DIR, get_logger
 
 log = get_logger("remote_index")
@@ -76,14 +77,7 @@ class IndexInvariantError(ValueError):
 
 
 def _check_invariants(data: dict) -> None:
-    """
-    Raise IndexInvariantError if the parsed JSON looks structurally wrong.
-
-    Imported lazily inside the function to avoid a circular import — the
-    expected schema_version lives in `index.py`.
-    """
-    from .index import INDEX_SCHEMA_VERSION
-
+    """Raise IndexInvariantError if the parsed JSON looks structurally wrong."""
     if data.get("schema_version") != INDEX_SCHEMA_VERSION:
         raise IndexInvariantError(
             f"schema_version is {data.get('schema_version')!r}, expected {INDEX_SCHEMA_VERSION}"

--- a/src/vipmp_docs_mcp/validator.py
+++ b/src/vipmp_docs_mcp/validator.py
@@ -47,12 +47,10 @@ log = get_logger("validator")
 try:
     import regex as _regex_engine  # third-party — full Java-compatible Unicode
 
-    _REGEX_ENGINE_NAME = "regex"
     _REGEX_FALLBACK = False
 except ImportError:  # pragma: no cover - exercised on minimal installs
     import re as _regex_engine
 
-    _REGEX_ENGINE_NAME = "re"
     _REGEX_FALLBACK = True
 
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -17,11 +17,19 @@ from mcp.server.fastmcp import FastMCP
 
 from vipmp_docs_mcp.prompts import register_prompts
 
+# Marker used in place of a body when a prompt raises while rendering, so the
+# failure surfaces with its cause instead of the prompt simply going missing.
+RENDER_FAILED = "<render failed:"
+
 
 def _rendered_prompts() -> dict[str, str]:
     """Register all prompts on a throwaway FastMCP instance and return
     {prompt_name: rendered_body} for every walkthrough (no-arg prompts
-    only — the parameterised ones are exercised by their callers)."""
+    only — the parameterised ones are exercised by their callers).
+
+    A prompt that raises while rendering is recorded with its traceback as
+    the body rather than dropped, so the assertions below fail with the
+    underlying error instead of a bare "didn't render"."""
     mcp = FastMCP("test")
     register_prompts(mcp)
 
@@ -39,11 +47,12 @@ def _rendered_prompts() -> dict[str, str]:
             continue
         try:
             result = asyncio.run(mcp.get_prompt(p.name, arguments={}))
-            out[p.name] = "\n".join(
-                m.content.text for m in result.messages if hasattr(m.content, "text")
-            )
-        except Exception:
-            pass
+        except Exception as exc:
+            out[p.name] = f"{RENDER_FAILED} {type(exc).__name__}: {exc}>"
+            continue
+        out[p.name] = "\n".join(
+            m.content.text for m in result.messages if hasattr(m.content, "text")
+        )
     return out
 
 
@@ -71,6 +80,12 @@ class TestWalkthroughInvariants:
         rendered = _rendered_prompts()
         missing = self.WALKTHROUGH_NAMES - rendered.keys()
         assert not missing, f"these walkthroughs didn't render: {missing}"
+        failed = {
+            name: rendered[name]
+            for name in self.WALKTHROUGH_NAMES
+            if rendered[name].startswith(RENDER_FAILED)
+        }
+        assert not failed, f"these walkthroughs raised while rendering: {failed}"
 
     def test_every_walkthrough_promises_adobe_sole_source(self):
         rendered = _rendered_prompts()


### PR DESCRIPTION
Six open code-scanning alerts, **all `note`-level quality findings — no security severities**. Five were real and are fixed here; one is a false positive, dismissed with rationale.

| # | Rule | Location | Action |
|---|---|---|---|
| 3, 4 | `py/cyclic-import` | `index.py`, `remote_index.py` | Fixed — cycle removed |
| 1 | `py/empty-except` | `tests/test_prompts.py` | Fixed — cause now reported |
| 5, 6 | `py/unused-global-variable` | `validator.py` | Fixed — dead global removed |
| 2 | `py/ineffectual-statement` | `fetcher.py` | **Dismissed** — false positive |

## Import cycle (3, 4)

`INDEX_SCHEMA_VERSION` lived in `index.py`, but `remote_index._check_invariants` needed it — so each module imported the other from *inside a function* to defer the cycle. `index.py`'s comment even asserted "remote_index doesn't import index", which stopped being true when the invariant check was added in 0.9.0.

The constant now lives in a leaf module, `index_schema.py`. Both import it at module level, and `index.py`'s deferred `from .remote_index import ensure_fresh` is promoted to a normal import now that nothing points back.

Verified the package's module-level import graph is **acyclic** (DFS over all `from .x import` edges). `INDEX_SCHEMA_VERSION` is still importable from `vipmp_docs_mcp.index`, so `tests/` and `refresh-index.yml` are unaffected — confirmed both import paths resolve to the same object.

## Empty except (1)

`_rendered_prompts` caught every exception with a bare `pass`, so a template that raised became a missing dict key and the test said "didn't render" with no cause.

Failures are now recorded against the prompt name behind a `RENDER_FAILED` marker **and asserted on** in `test_all_walkthroughs_render`. That second part matters: without it the placeholder body would have satisfied the existing key-presence check and left the test *weaker* than before.

Confirmed by forcing a prompt to raise — the test now fails with `these walkthroughs raised while rendering: {'learn_3yc': '<render failed: RuntimeError: simulated template failure>'}` instead of passing silently.

## Dead global (5, 6)

`_REGEX_ENGINE_NAME` was assigned in both branches of the `regex`/`re` import fallback and never read. Its sibling `_REGEX_FALLBACK` *is* used, so only the unused name is gone.

## Dismissed as false positive (2)

`await maybe_aw` in `fetcher.py` plainly has an effect — it runs the `on_progress` coroutine. CodeQL can't infer the variable is awaitable and treats the expression statement as value-discarding.

`tests/test_async_fetcher.py::test_async_progress_callback_awaited` passes an async callback and asserts it ran; the assertion fails if the await is removed. Satisfying the query would mean assigning the result to a variable nobody reads — trading a false positive for a real one. Dismissed via the API with that reasoning recorded on the alert.

## Verification

- `ruff check` + `ruff format --check` clean across all four paths.
- Full suite: **211 passed**.
- Import graph proven acyclic; both `INDEX_SCHEMA_VERSION` import paths verified identical.

CHANGELOG updated under `[Unreleased]`. Its lead-in no longer claims nothing in the shipped package changed, since this touches `src/` — though there is no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)