### PR TITLE
ci: bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
           # Admin PAT, not GITHUB_TOKEN — needed to push straight to main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.python-version == '3.12'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: python
           # `security-and-quality` adds maintainability/quality queries on
@@ -39,6 +39,6 @@ jobs:
 
       # Python is interpreted — no build step. Analyze directly.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:python"

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip
@@ -76,7 +76,7 @@ jobs:
 
       - name: Open issue on failure
         if: failure() && steps.check.outputs.failed != '0'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/publish-mcpb.yml
+++ b/.github/workflows/publish-mcpb.yml
@@ -69,10 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload bundle as workflow artifact
         # Always available via the run page, regardless of release step.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mcpb-bundle
           path: ${{ steps.pack.outputs.bundle }}
@@ -128,7 +128,7 @@ jobs:
         # Creates the Release if the tag doesn't have one yet, otherwise
         # updates it. Skipped for workflow_dispatch runs (no tag context).
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.pack.outputs.bundle }}
           fail_on_unmatched_files: true

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -84,10 +84,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/refresh-index.yml
+++ b/.github/workflows/refresh-index.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: pip
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload Adobe response artifact
         if: failure() && steps.rebuild.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: adobe-sitemap-debug
           path: adobe-sitemap-debug/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ script, docs, and internal restructuring with no effect on tool output.
   > than worked around.
 
 ### Changed
+- **GitHub Actions bumped to current majors** across all seven workflows:
+  `checkout` v6→v7, `setup-python` v6→v7, `upload-artifact` v6/v4→v7,
+  `setup-node` v5→v7, `github-script` v7→v9, `codeql-action` v3→v4,
+  `action-gh-release` v2→v3. `upload-artifact` had drifted apart — v6 in
+  `ci.yml` but v4 in `publish-mcpb.yml` and `refresh-index.yml`.
+  `create-pull-request@v8` and `gh-action-pypi-publish@release/v1` were
+  already current.
 - **`ruff check` and `ruff format --check` now gate `scripts/` and
   `examples/`** as well as `src/` and `tests/`, closing the gap that let those
   two drift after 0.12.0 gated only half the tree `CONTRIBUTING.md` asks


### PR DESCRIPTION
Checked each action's latest major against the GitHub API rather than assuming, and read the release notes for every major crossed.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v6 | **v7** |
| `actions/setup-python` | v6 | **v7** |
| `actions/upload-artifact` | v6 *(ci)* / v4 *(×2)* | **v7** |
| `actions/setup-node` | v5 | **v7** |
| `actions/github-script` | v7 | **v9** |
| `github/codeql-action` (init + analyze) | v3 | **v4** |
| `softprops/action-gh-release` | v2 | **v3** |
| `peter-evans/create-pull-request` | v8 | v8 — already current (latest v8.1.1) |
| `pypa/gh-action-pypi-publish` | `release/v1` | unchanged — the floating ref PyPA recommends |

**`upload-artifact` had drifted apart:** v6 in `ci.yml` but v4 in `publish-mcpb.yml` and `refresh-index.yml`. All three now match.

## Breaking changes checked against actual usage

Every major bump was verified against what we actually call, not just bumped:

- **`setup-python` v7 removed the `pip-install` input.** We only pass `python-version` and `cache: pip` — unaffected.
- **`github-script` v9 breaks `require('@actions/github')`** and scripts that redeclare `getOctokit` as `const`/`let`. The link-check script uses neither — only `require('fs')`, which v9's README still documents for script loading.
- **`setup-node` v7 dropped the dummy `NODE_AUTH_TOKEN` export.** We only pass `node-version: '22'` and never publish to npm.
- **`upload-artifact`:** v5 was the node24 bump, v6/v7 added the opt-in `archive` input. All three call sites upload a single uniquely-named artifact, so the old v3→v4 naming break never applied and nothing since affects us.
- **`checkout` v7 now blocks checking out fork PRs** under `pull_request_target` and `workflow_run`. No workflow uses either trigger.
- **`action-gh-release` v3** is a node20→node24 runtime move.

## Verification

All seven workflow files still parse as YAML. The real test is this PR's own run — it exercises `checkout@v7`, `setup-python@v7`, `upload-artifact@v7`, and `codeql-action@v4`.

Not exercised by CI, so worth watching on first use: `github-script@v9` (link-check, weekly and only on failure), `setup-node@v7` + `action-gh-release@v3` (publish-mcpb, tag-triggered), and `create-pull-request@v8` (refresh-index, daily).

## Follow-up finding

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` is set in all seven workflows and is **now a no-op** — every action above natively declares `using: node24` (verified by reading each pinned `action.yml`), and `codeql-action` is composite. I left it in place rather than widen this PR beyond version bumps; happy to strip it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)