### PR TITLE
fix: group Dependabot dev dependencies by name pattern, not dependency-type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 version: 2
 updates:
-  # Python dependencies declared in pyproject.toml and locked in uv.lock.
-  # The `uv` ecosystem (not `pip`) is what keeps the lockfile in step, which
-  # matters here because CI installs from it.
+  # Python dependencies declared in pyproject.toml. Note the project does not
+  # commit a lockfile — uv.lock is gitignored and CI installs with
+  # `pip install -e ".[dev]"` — so updates land in pyproject.toml alone. The
+  # `uv` ecosystem is used because uv is the project's dependency tool; it
+  # reads PEP 621 metadata and would maintain uv.lock if one were tracked.
   #
   # Runtime and dev updates are grouped separately: a runtime bump changes what
   # `pip install vipmp-docs-mcp` resolves for users and deserves its own review,
@@ -18,15 +20,27 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    # Grouped by explicit name patterns, NOT `dependency-type`. Dependabot does
+    # not treat PEP 621 `[project.optional-dependencies]` as development, so a
+    # `dependency-type: development` group matches nothing here and every dev
+    # tool lands in the production group — which is what happened to `ruff` in
+    # PR #35. Dev patterns are listed first so they win the match.
+    #
+    # This list has to stay in step with the `dev` extra in pyproject.toml;
+    # tests/test_dependabot.py fails if a dev dependency isn't covered.
     groups:
-      runtime-dependencies:
-        dependency-type: "production"
-        patterns:
-          - "*"
       dev-dependencies:
-        dependency-type: "development"
+        patterns:
+          - "pytest*"
+          - "ruff"
+          - "pyyaml"
+      runtime-dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "pytest*"
+          - "ruff"
+          - "pyyaml"
 
   # Actions used by the workflows in .github/workflows/. Grouped into one PR —
   # these move together (the Node 20 to 24 migration bumped most of them at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ script, docs, and internal restructuring with no effect on tool output.
   apart from test tooling. Dependabot branches are prefixed `dependabot/`, not
   `bot/`, so a merge does not trigger `auto-version-bump.yml`.
 
+  The dev/runtime split is by **name pattern**, not `dependency-type`:
+  Dependabot doesn't treat PEP 621 `[project.optional-dependencies]` as
+  development, so a `dependency-type: development` group matches nothing and
+  every dev tool falls into the production group — as `ruff` did on the first
+  run. `tests/test_dependabot.py` holds the pattern list to the `dev` extra so
+  it can't drift, and `pyyaml` was added to the `dev` extra for it.
+
 ### Changed
 - **Removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** from all seven workflows. It
   was masking the Node 20 deprecation warning that `upload-artifact@v4` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,14 +195,23 @@ Runtime and dev are deliberately separate: a runtime bump changes what
 `pip install vipmp-docs-mcp` gives users and deserves closer review than a
 pytest bump.
 
-Two things to know when reviewing them:
+**Adding a dev dependency means updating `dependabot.yml`.** The
+`dev-dependencies` group is a hand-written list of name patterns, because
+Dependabot doesn't recognise PEP 621 `[project.optional-dependencies]` as
+development deps — a `dependency-type: development` group matches nothing here.
+Add the new package to both the group's `patterns` and the runtime group's
+`exclude-patterns`; `tests/test_dependabot.py` fails if you forget.
+
+Two things to know when reviewing the PRs:
 
 - **A Dependabot merge does not cut a release.** `auto-version-bump.yml` only
   fires for branches prefixed `bot/`, and Dependabot uses `dependabot/…`. If a
   dependency bump should ship, tag it manually (see Releases above).
-- **`ruff` is pinned below the next minor** (`>=0.15.0,<0.16`) because lint
-  rules change between minors. Dependabot cannot cross that ceiling on its own;
-  widening it is a deliberate call, and expect new lint findings when you do.
+- **`ruff` is capped below the next minor** (`>=0.15.0,<0.16`) because lint
+  rules change between minors. Dependabot *will* propose widening that ceiling
+  when a new minor lands — it raises the cap rather than leaving ruff alone —
+  so treat those PRs as a deliberate decision: check CI is green on the new
+  minor before merging, since a rule change can surface fresh findings.
 
 ## Reporting security issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dev = [
     "pytest-cov>=5.0.0",
     "pytest-httpx>=0.35.0",
     "ruff>=0.15.0,<0.16",
+    # Used by tests/test_dependabot.py to read .github/dependabot.yml.
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/tests/test_dependabot.py
+++ b/tests/test_dependabot.py
@@ -1,0 +1,104 @@
+"""
+Tests that keep .github/dependabot.yml in step with pyproject.toml.
+
+The `dev-dependencies` group is a hand-written list of name patterns, because
+Dependabot does not recognise PEP 621 `[project.optional-dependencies]` as
+development dependencies — a `dependency-type: development` group matches
+nothing here, which is how `ruff` ended up grouped as a runtime dependency.
+A hand-written list drifts, so these tests hold it to the `dev` extra.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEPENDABOT_PATH = REPO_ROOT / ".github" / "dependabot.yml"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+
+def _dependabot() -> dict:
+    return yaml.safe_load(DEPENDABOT_PATH.read_text(encoding="utf-8"))
+
+
+def _uv_update_config() -> dict:
+    for update in _dependabot()["updates"]:
+        if update["package-ecosystem"] == "uv":
+            return update
+    raise AssertionError("no `uv` ecosystem entry in dependabot.yml")
+
+
+def _requirement_names(specifiers: list[str]) -> set[str]:
+    """Package names from PEP 508 specifiers, lowercased.
+
+    Splits on the first character that can't be part of a name, so
+    `ruff>=0.15.0,<0.16` and `mcp[cli]>=1.0.0` both reduce to their name.
+    """
+    names = set()
+    for spec in specifiers:
+        name = spec
+        for sep in ("[", ">", "<", "=", "!", "~", ";", " "):
+            name = name.split(sep)[0]
+        names.add(name.strip().lower())
+    return names
+
+
+def _dev_dependency_names() -> set[str]:
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    return _requirement_names(pyproject["project"]["optional-dependencies"]["dev"])
+
+
+def _runtime_dependency_names() -> set[str]:
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    return _requirement_names(pyproject["project"]["dependencies"])
+
+
+def _matches_any(name: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+
+
+class TestDevDependencyGrouping:
+    """
+    Every dev dependency must be covered by the `dev-dependencies` patterns,
+    and excluded from the catch-all runtime group. Otherwise a dev-tool bump
+    is presented for review as though it changed what users install.
+    """
+
+    def test_every_dev_dependency_matches_a_dev_pattern(self):
+        groups = _uv_update_config()["groups"]
+        patterns = groups["dev-dependencies"]["patterns"]
+        unmatched = {name for name in _dev_dependency_names() if not _matches_any(name, patterns)}
+        assert not unmatched, (
+            f"dev dependencies not covered by dependabot.yml dev-dependencies "
+            f"patterns {patterns}: {sorted(unmatched)}"
+        )
+
+    def test_every_dev_dependency_is_excluded_from_the_runtime_group(self):
+        groups = _uv_update_config()["groups"]
+        excludes = groups["runtime-dependencies"].get("exclude-patterns", [])
+        leaked = {name for name in _dev_dependency_names() if not _matches_any(name, excludes)}
+        assert not leaked, (
+            f"dev dependencies not excluded from the runtime-dependencies group "
+            f"{excludes}: {sorted(leaked)}"
+        )
+
+    def test_no_runtime_dependency_is_captured_by_a_dev_pattern(self):
+        """The dev patterns are matched first, so an over-broad one would
+        silently pull a runtime dependency out of the runtime group."""
+        patterns = _uv_update_config()["groups"]["dev-dependencies"]["patterns"]
+        captured = {name for name in _runtime_dependency_names() if _matches_any(name, patterns)}
+        assert not captured, (
+            f"runtime dependencies wrongly matched by dev patterns {patterns}: {sorted(captured)}"
+        )
+
+
+class TestEcosystemCoverage:
+    """The repo has Python dependencies and GitHub Actions; both need an entry."""
+
+    def test_both_ecosystems_are_configured(self):
+        ecosystems = {u["package-ecosystem"] for u in _dependabot()["updates"]}
+        assert {"uv", "github-actions"} <= ecosystems, ecosystems


### PR DESCRIPTION
Dependabot's first run exposed a bug in the config I added in #34 — plus two false claims I wrote alongside it.

## The bug

Dependabot opened **#35** bumping `ruff` — a dev tool — inside the **`runtime-dependencies`** group.

`dependency-type: development` does not match PEP 621 `[project.optional-dependencies]`. Dependabot treats extras as production, so the development group matched **nothing** and every dev tool fell through to the production catch-all. The dev/runtime split that was the entire point of the config did not work.

Now grouped by explicit name patterns, dev first so it wins the match, with matching `exclude-patterns` on the runtime group.

## Guarding the new hardcoded list

That trades one hardcoded list for another — the same drift that caused the 0.13.1 manifest bug. So `tests/test_dependabot.py` holds the patterns to the `dev` extra and fails if:

- a dev dependency isn't covered by the dev patterns
- a dev dependency isn't excluded from the runtime group
- a dev pattern is broad enough to capture a *runtime* dependency

Verified by adding a fake `mypy>=1.0` dev dependency: two tests fail naming it. `pyyaml` was added to the dev extra to read the config (and is therefore covered by the patterns it checks).

## Two false claims from #34, corrected

**1. CONTRIBUTING said Dependabot "cannot cross" the ruff `<0.16` ceiling**, and that widening it is a deliberate manual call. It plainly can — #35 proposes `<0.17`. It now says Dependabot raises the cap itself, and those PRs need CI checked on the new minor before merging.

I tested it: **ruff 0.16.0 passes clean** here — `check` and `format --check` across all four paths, no new findings. So **#35 is safe to take**; it'll rebase itself onto this once merged.

**2. The `dependabot.yml` comment said** the `uv` ecosystem "keeps the lockfile in step, which matters here because CI installs from it." Neither half is true — `.gitignore` deliberately excludes `uv.lock` ("The project doesn't ship a committed lock (CI uses pip)") and CI installs with `pip install -e ".[dev]"`. Updates land in `pyproject.toml` alone. The `uv` ecosystem is still the right choice — uv is the project's tool, it reads PEP 621, and #35 proves it works — but the comment now says why rather than something wrong.

## Verification

215 tests pass (211 + 4 new); ruff `check` and `format --check` clean on all four paths; `dependabot.yml` parses with the groups in the intended order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)