### PR TITLE
chore(deps): widen ruff ceiling to <0.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
     "pytest-httpx>=0.35.0",
-    "ruff>=0.15.0,<0.16",
+    "ruff>=0.15.0,<0.17",
     # Used by tests/test_dependabot.py to read .github/dependabot.yml.
     "pyyaml>=6.0",
 ]


### PR DESCRIPTION
Applies the bump Dependabot proposed in #35, which auto-closed before it could be merged.

## Why this is a hand-written PR rather than Dependabot's

#35 conflicted once #36 added `pyyaml` on the line directly below `ruff` in the `dev` extra. Asking Dependabot to rebase made it **close** the PR instead:

> Looks like ruff is no longer updatable, so this is no longer needed.

That's a side effect of #36 correcting the grouping — `ruff` moved out of the `runtime-dependencies` group the PR was filed under, so Dependabot treated it as obsolete. A replacement would only appear on the next scheduled run (Monday), so rather than leave a verified-safe bump waiting, here it is directly.

## Verification

Validated against **ruff 0.16.0** — the version CI's `pip install -e ".[dev]"` now resolves under the widened ceiling:

- `ruff check` across `src/ tests/ scripts/ examples/` — **All checks passed**
- `ruff format --check` across all four — **43 files already formatted**, nothing to reformat
- **215 tests pass**

The reason the cap exists — lint rules changing between minors — doesn't bite on this jump: no new findings and no formatting churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)