### PR TITLE
fix: migrate to the mcp 2.0 server API, release 0.14.0

### DIFF
--- a/.github/workflows/refresh-index.yml
+++ b/.github/workflows/refresh-index.yml
@@ -152,17 +152,25 @@ jobs:
       - name: Validate structural invariants
         # Fail-loud guard against poisoning / parser regressions before the
         # PR ever opens. Same floors that `remote_index._check_invariants`
-        # enforces at fetch time, plus a parse-error fraction check that
-        # mirrors `STALE_INDEX_FAILURE_FRACTION` in server.py. If any
-        # invariant fails the workflow fails and no PR is opened — the
+        # enforces at fetch time, plus the `STALE_INDEX_FAILURE_FRACTION`
+        # parse-error check that `vipmp_server_info` reports at runtime. If
+        # any invariant fails the workflow fails and no PR is opened — the
         # daily refresh just pauses until a human investigates.
+        #
+        # Import only from the index modules, never from `server`: pulling in
+        # the server module drags in the MCP SDK, so an SDK release can break
+        # this check even when the rebuild itself is healthy (mcp 2.0.0 did
+        # exactly that on 2026-07-28).
         run: |
           python - <<'PY'
           import json
           import sys
           from pathlib import Path
 
-          from vipmp_docs_mcp.index import INDEX_SCHEMA_VERSION
+          from vipmp_docs_mcp.index import (
+              INDEX_SCHEMA_VERSION,
+              STALE_INDEX_FAILURE_FRACTION,
+          )
           from vipmp_docs_mcp.remote_index import (
               MIN_ENDPOINTS,
               MIN_ERROR_CODES,
@@ -171,7 +179,6 @@ jobs:
               _check_invariants,
               IndexInvariantError,
           )
-          from vipmp_docs_mcp.server import STALE_INDEX_FAILURE_FRACTION
 
           path = Path("src/vipmp_docs_mcp/data/index.json")
           data = json.loads(path.read_text(encoding="utf-8"))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,28 @@ The rest is CI config, a dev script, docs, and internal restructuring.
   Three separate fixes, because the pin was only the trigger:
   the package now targets the 2.0 API, the requirement carries a `<3`
   ceiling, and the validation step no longer imports from `server`.
+- **README inaccuracies**, found by a full pass over it and each verified
+  against the code rather than read for plausibility:
+  - `vipmp_server_info` was **undocumented** — registered, declared in
+    `manifest.json` and smoke-tested since 0.10.0, but absent from every tool
+    table, so 19 of 20 tools were listed.
+  - The tool tables still cited **`get_vipmp_releases`**, removed in 0.12.0 in
+    favour of `list_vipmp_releases`.
+  - The index section described **three tiers and omitted the
+    GitHub-refreshed remote tier** entirely — the 12h-TTL layer that is the
+    only reason a PyPI install sees the daily refresh at all. Neither the tier,
+    its TTL, its fail-soft behaviour, nor the `VIPMP_DISABLE_REMOTE_INDEX`
+    opt-out appeared anywhere. Two nearby paragraphs consequently understated
+    reach, claiming only git-source installs pick up index refreshes.
+  - The baseline was described as refreshed **weekly**, contradicting the two
+    other places that correctly said daily (`23 4 * * *`).
+  - `generate_vipmp_request`'s second parameter was documented as `body`; it
+    is `body_json`.
+  - The Development section ran `ruff check src/ tests/` and no format check,
+    so following the README passed locally while CI — which gates `scripts/`
+    and `examples/` too — failed. The test suite was described as **56**
+    tests; it is 218.
+  - The version-pinning example pinned `==0.6.1`, eight minor versions back.
 - **Resolved the `index` ↔ `remote_index` import cycle.** `INDEX_SCHEMA_VERSION`
   lived in `index.py` but `remote_index._check_invariants` needed it, so each
   module reached for the other through a function-local import. The constant
@@ -49,6 +71,14 @@ The rest is CI config, a dev script, docs, and internal restructuring.
   > than worked around.
 
 ### Added
+- **README tool-parity tests** (`tests/test_readme.py`). CI now fails if the
+  README omits a tool the server registers or cites one it doesn't — the two
+  drifts fixed above, which `tests/test_manifest.py` already caught for
+  `manifest.json` but nothing caught for the prose. Both directions were
+  mutation-tested against the real drift rather than assumed to work; doing so
+  caught two bugs in the check itself (a pattern that silently skipped every
+  tool whose name *starts* with `vipmp`, and prompt names counted as stale
+  tools).
 - **The server now reports its version in the initialize handshake.**
   `MCPServer(version=__version__)` — the installed distribution version, which
   `auto-version-bump.yml` keeps in lockstep with `manifest.json`, so what a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Merged to main but not yet released. No behaviour changes — CI config, a dev
-script, docs, and internal restructuring with no effect on tool output.
+## [0.14.0] — 2026-07-29
+
+Tool output is unchanged, but this release **requires `mcp` 2.x** — see the
+migration note below — and the server now advertises its version to clients.
+The rest is CI config, a dev script, docs, and internal restructuring.
 
 ### Fixed
+- **The daily index refresh, broken by the `mcp` 2.0.0 release.** The SDK's
+  2.0.0 published on 2026-07-28 and moved `mcp.server.fastmcp.FastMCP` to
+  `mcp.server.mcpserver.MCPServer`. `pyproject.toml` pinned `mcp[cli]>=1.0.0`
+  with no ceiling, so the next scheduled run resolved 2.0.0 and failed on
+  `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` — not in the
+  rebuild, which succeeded, but in the **Validate structural invariants**
+  step, which imported `STALE_INDEX_FAILURE_FRACTION` from `server.py` and so
+  dragged in the whole SDK to read one float.
+
+  Three separate fixes, because the pin was only the trigger:
+  the package now targets the 2.0 API, the requirement carries a `<3`
+  ceiling, and the validation step no longer imports from `server`.
 - **Resolved the `index` ↔ `remote_index` import cycle.** `INDEX_SCHEMA_VERSION`
   lived in `index.py` but `remote_index._check_invariants` needed it, so each
   module reached for the other through a function-local import. The constant
@@ -34,6 +49,15 @@ script, docs, and internal restructuring with no effect on tool output.
   > than worked around.
 
 ### Added
+- **The server now reports its version in the initialize handshake.**
+  `MCPServer(version=__version__)` — the installed distribution version, which
+  `auto-version-bump.yml` keeps in lockstep with `manifest.json`, so what a
+  client sees matches the .mcpb bundle release. FastMCP 1.x had no `version`
+  parameter, so the handshake had always sent an empty string —
+  `examples/list_tools.py` printed a bare `v` on connect, unnoticed for the
+  whole 1.x era. `tests/test_manifest.py` now asserts the handshake version
+  is wired to the package metadata and is not empty, alongside the existing
+  `manifest.json` ↔ `pyproject.toml` parity check.
 - **Dependabot** (`.github/dependabot.yml`) — weekly grouped PRs for the `uv`
   and `github-actions` ecosystems. Runtime and dev Python updates are grouped
   separately so a bump that changes what users resolve on install is reviewed
@@ -56,6 +80,20 @@ script, docs, and internal restructuring with no effect on tool output.
   it can't drift, and `pyyaml` was added to the `dev` extra for it.
 
 ### Changed
+- **Migrated to the `mcp` 2.0 server API**, and the requirement is now
+  `mcp[cli]>=2.0.0,<3` (was `>=1.0.0`, unbounded). The server surface is a
+  rename — `FastMCP` → `MCPServer` from `mcp.server.mcpserver`, with
+  `.tool()`, `.prompt()` and `.run()` unchanged and `ToolAnnotations` still
+  accepting its camelCase aliases — so all 20 tools and 13 prompts register
+  and serve identically. The one behavioural break was client-side:
+  `InitializeResult.serverInfo` is now `server_info` (2.0 renamed model fields
+  to snake_case, and aliases cover construction but not attribute access),
+  which affected `scripts/smoke_test.py` and `examples/list_tools.py`.
+- **`STALE_INDEX_FAILURE_FRACTION` moved from `server.py` to `index.py`**, next
+  to the `parse_errors` and `source_sitemap_size` fields it is measured
+  against. `refresh-index.yml`'s validation step imports it from there, so
+  the step no longer needs the MCP SDK — an SDK release can't break the
+  index refresh again. `vipmp_server_info` reads it from the new location.
 - **Removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** from all seven workflows. It
   was masking the Node 20 deprecation warning that `upload-artifact@v4` and
   `action-gh-release@v2` emitted in `publish-mcpb`; with every action now on a
@@ -662,7 +700,8 @@ refresh PR merged. No code changes.
 - `<br />` tags encoded as literal text (`&lt;br /&gt;`) in Adobe's
   table cells are now parsed into line breaks.
 
-[Unreleased]: https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/compare/v0.13.1...v0.14.0
 [0.13.1]: https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/compare/v0.11.0...v0.12.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ All of these run in CI on every PR. Keep them green.
 
 ```
 src/vipmp_docs_mcp/
-├── server.py             # FastMCP entry point — tool/prompt registration
+├── server.py             # MCPServer entry point — tool/prompt registration
 ├── fetcher.py            # HTTP client (retries + trailing-slash fallback)
 ├── cache.py              # Disk cache with TTL + ETag
 ├── sitemap.py            # Hand-curated fallback sitemap

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Claude calls one of the tools below, the server fetches and parses the relevant 
 |---|---|
 | `describe_vipmp_endpoint(method, path)` | **One-shot profile**: schema + error codes + release-note mentions + cross-references in a single call. The fastest way to understand an endpoint end-to-end. |
 | `validate_vipmp_request(endpoint, body_json)` | Programmatically checks a JSON body against the documented schema. Catches unknown fields, missing required fields, type mismatches, constraint violations (e.g. "Max: 35 characters"), and deprecated-field usage. |
-| `generate_vipmp_request(endpoint, body?, language?)` | Emits a runnable snippet in `curl` / `powershell` / `python` (httpx) / `csharp` (HttpClient). Builds a placeholder body from the schema when you don't supply one. |
+| `generate_vipmp_request(endpoint, body_json?, language?)` | Emits a runnable snippet in `curl` / `powershell` / `python` (httpx) / `csharp` (HttpClient). Builds a placeholder body from the schema when you don't supply one. |
 
 ### Structured extractors
 | Tool | What it does |
@@ -57,6 +57,7 @@ Claude calls one of the tools below, the server fetches and parses the relevant 
 | `vipmp_cache_clear(path?)` | Drop one entry or the whole cache. |
 | `refresh_vipmp_sitemap()` | Rebuild the sitemap from Adobe's published `/sitemap.xml`. Run when you're seeing 404s or think the sitemap has drifted. |
 | `rebuild_vipmp_index()` | Rebuild the pre-extracted index of endpoints/error codes/schemas (~60s). Run to refresh the data behind the structured tools between package updates. |
+| `vipmp_server_info()` | Diagnostic dump — package version, Python version, which index tier is active and how old it is, sitemap size, cache stats, log path. The right first call for "what version am I on?" or "why is this not working?". |
 
 ### SoftwareOne operational tips
 | Tool | What it does |
@@ -119,7 +120,7 @@ If you have [uv](https://docs.astral.sh/uv/) installed, drop this into `%APPDATA
   "mcpServers": {
     "vipmp-docs": {
       "command": "uvx",
-      "args": ["vipmp-docs-mcp==0.6.1"]
+      "args": ["vipmp-docs-mcp==0.14.0"]
     }
   }
 }
@@ -235,7 +236,7 @@ The `list_vipmp_releases` tool serves structured, dated entries pulled from Adob
 
 Each entry has an ISO date (where available), a section, and one or more changes with titles and Markdown bodies — so filtering by "what changed since February" is a one-line call.
 
-**Daily refresh.** The [`refresh-index.yml`](.github/workflows/refresh-index.yml) GitHub Action runs daily (04:23 UTC), rebuilds the index including releases, and opens a PR if anything changed. Published installs (`pip install -e .`, `uvx --from git+...`) pick up updates automatically once the PR merges. For bleeding-edge, call `rebuild_vipmp_index` locally.
+**Daily refresh.** The [`refresh-index.yml`](.github/workflows/refresh-index.yml) GitHub Action runs daily (04:23 UTC), rebuilds the index including releases, and opens a PR if anything changed. Once that PR merges, **every** install picks the refresh up within 12 hours via the GitHub-refreshed index tier — including plain `uvx vipmp-docs-mcp` from PyPI, which no longer has to wait for a release. For bleeding-edge, call `rebuild_vipmp_index` locally.
 
 **Prompting patterns:**
 
@@ -257,15 +258,18 @@ Sections are kept separate because they mean different things: `api_changes` is 
 
 ## The structured index
 
-The `list_vipmp_endpoints`, `list_vipmp_error_codes`, `list_vipmp_status_codes`, `get_vipmp_schema`, and `get_vipmp_releases` tools are all served from a **pre-built index** — a single JSON file that captures every endpoint, error code, status code, and field schema extracted from Adobe's docs. With the index in place these tools answer in **single-digit milliseconds**. Without it, they fall back to live extraction across ~86 pages (~30s cold, ~5s warm).
+The `list_vipmp_endpoints`, `list_vipmp_error_codes`, `list_vipmp_status_codes`, `get_vipmp_schema`, and `list_vipmp_releases` tools are all served from a **pre-built index** — a single JSON file that captures every endpoint, error code, status code, and field schema extracted from Adobe's docs. With the index in place these tools answer in **single-digit milliseconds**. Without it, they fall back to live extraction across ~86 pages (~30s cold, ~5s warm).
 
-**Three-tier resolution for the active index:**
+**Four-tier resolution for the active index** — first usable source wins:
 
 1. **User-local rebuild** (`~/.cache/swo-adobe-vipm-docs-mcp/index.json`) — freshest. Written by the `rebuild_vipmp_index` MCP tool when you run it.
-2. **Package-shipped baseline** (`src/vipmp_docs_mcp/data/index.json`) — what you get out of the box. Refreshed weekly by the `refresh-index.yml` GitHub Action and included in each release.
-3. **None** — tools fall back to live extraction. The output annotates this so you know.
+2. **GitHub-refreshed remote** (`~/.cache/swo-adobe-vipm-docs-mcp/remote-index.json`) — pulled on demand from `main` with a 12-hour TTL, so the daily refresh reaches you without waiting for a PyPI release. A conditional `If-None-Match` GET, so a 304 costs nothing. Always stale-OK: any failure (offline, rate limit, DNS, GitHub 5xx) falls through to the next tier with a logged warning, and a fetched copy must pass the same structural floors CI enforces before it is trusted. Opt out with `VIPMP_DISABLE_REMOTE_INDEX=1` for deterministic or air-gapped runs.
+3. **Package-shipped baseline** (`src/vipmp_docs_mcp/data/index.json`) — what you get out of the box. Refreshed daily by the `refresh-index.yml` GitHub Action and included in each release.
+4. **None** — tools fall back to live extraction. The output annotates this so you know.
 
-**Keeping the baseline fresh:** a GitHub Action ([`refresh-index.yml`](.github/workflows/refresh-index.yml)) runs **daily** (release notes change frequently) and also on demand via `workflow_dispatch`. It rebuilds the index against live Adobe docs and, if anything changed (new endpoint, removed error code, schema drift, fresh release entry, etc.), opens a PR for human review. Merging that PR publishes the new baseline to `pip install -e .` / `uvx --from git+...` installs automatically. Days where nothing changes produce no PR.
+`vipmp_server_info` reports which tier is actually in play, which is the quickest way to answer "is my index stale?".
+
+**Keeping the baseline fresh:** a GitHub Action ([`refresh-index.yml`](.github/workflows/refresh-index.yml)) runs **daily** (release notes change frequently) and also on demand via `workflow_dispatch`. It rebuilds the index against live Adobe docs and, if anything changed (new endpoint, removed error code, schema drift, fresh release entry, etc.), opens a PR for human review. Before that PR opens, the rebuilt index has to clear the same structural floors the remote tier enforces — endpoint, error-code, status-code and schema minimums plus a parse-error ceiling — so a parser regression or a mass deletion fails the workflow instead of shipping. Merging publishes the new baseline to git-source installs immediately and to every other install within the remote tier's 12-hour TTL. Days where nothing changes produce no PR.
 
 **Running on demand:**
 ```bash
@@ -299,11 +303,14 @@ The server logs to a rotating file so transient failures are debuggable:
 
 ```bash
 pip install -e ".[dev]"
-ruff check src/ tests/
+ruff check src/ tests/ scripts/ examples/
+ruff format --check src/ tests/ scripts/ examples/
 pytest -v
 ```
 
-The test suite is 56 pytest-mocked tests (no network required) covering parsers, cache, search, and fetcher retry logic.
+Lint and format gate all four directories, matching CI — checking only `src/` and `tests/` is how `scripts/` and `examples/` drifted after 0.12.0.
+
+The test suite is 216 pytest-mocked tests covering the parsers, cache, search, fetcher retry logic, validator, code generation, releases, tips, the remote-index tier, and manifest/server parity. `scripts/smoke_test.py` covers what unit tests can't — it drives the real server over stdio and needs network, so CI doesn't run it. Run it before tagging a release.
 
 ## Requirements
 

--- a/examples/list_tools.py
+++ b/examples/list_tools.py
@@ -33,7 +33,7 @@ async def main() -> None:
         ClientSession(read, write) as session,
     ):
         init = await session.initialize()
-        print(f"Connected to {init.serverInfo.name} v{init.serverInfo.version}")
+        print(f"Connected to {init.server_info.name} v{init.server_info.version}")
         print()
 
         tools = await session.list_tools()

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "vipmp-docs-mcp",
   "display_name": "Adobe VIP Marketplace Docs",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools",
   "long_description": "Turn Adobe's Partner API docs at developer.adobe.com/vipmp/docs into queryable MCP tools. Search pages, inspect endpoints, validate request bodies against the published schemas, generate runnable curl/PowerShell/Python/C# snippets, and follow release notes \u2014 without leaving the assistant. Ships with a pre-built structured index of every endpoint, error code, and schema, refreshed daily from live Adobe docs.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "vipmp-docs-mcp"
-version = "0.13.1"
+version = "0.14.0"
 description = "MCP server exposing Adobe VIP Marketplace Partner API documentation as searchable tools"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -23,7 +23,11 @@ classifiers = [
     "Topic :: Software Development :: Documentation",
 ]
 dependencies = [
-    "mcp[cli]>=1.0.0",
+    # 2.0 renamed the server class: `mcp.server.fastmcp.FastMCP` became
+    # `mcp.server.mcpserver.MCPServer`. server.py imports the new path, so
+    # 1.x won't work. The `<3` ceiling is deliberate — an unbounded pin is
+    # what let 2.0.0 break the scheduled index refresh on release day.
+    "mcp[cli]>=2.0.0,<3",
     "httpx>=0.27.0",
     "beautifulsoup4>=4.12.0",
     "lxml>=5.0.0",

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -3,7 +3,7 @@ End-to-end smoke test for the MCP server.
 
 Starts `vipmp-docs-mcp` as a subprocess, connects over stdio using the
 MCP client SDK, and exercises the main tools + prompts. Catches regressions
-that unit tests can't — missing imports, broken FastMCP registration,
+that unit tests can't — missing imports, broken tool/prompt registration,
 transport failures, etc.
 
 Run from the repo root with the venv active:
@@ -97,7 +97,7 @@ async def main() -> int:
         # --- Handshake --------------------------------------------------
         print("Handshake")
         init = await session.initialize()
-        ok(f"server={init.serverInfo.name!r} version={init.serverInfo.version}")
+        ok(f"server={init.server_info.name!r} version={init.server_info.version}")
 
         # --- Discovery --------------------------------------------------
         print("\nDiscovery")

--- a/src/vipmp_docs_mcp/index.py
+++ b/src/vipmp_docs_mcp/index.py
@@ -57,6 +57,27 @@ USER_INDEX_PATH = CACHE_DIR / "index.json"
 PACKAGE_INDEX_PATH = Path(__file__).parent / "data" / "index.json"
 
 
+# Fraction of the source sitemap that must fail to parse before a snapshot
+# counts as suspiciously incomplete. Read by `vipmp_server_info` (to flag a
+# broken active index) and by the refresh-index workflow (to abort a bad
+# rebuild before it opens a PR). It lives here, next to the `parse_errors`
+# and `source_sitemap_size` fields it is measured against, so the CI check
+# doesn't have to import the MCP server module — and therefore the whole
+# MCP SDK — just to read a float.
+#
+# The real regression in #4 surfaced as 57/72 pages failing (~79% failure
+# rate) because CI was building against the stale hand-curated underscore
+# paths that Adobe had migrated off. A healthy build against Adobe's live
+# sitemap parses every page (0% failure). A small number of parse errors is
+# normal when Adobe publishes a new page the parser hasn't seen yet; 25%
+# gives us headroom for that without hiding real regressions.
+#
+# Prior versions used an absolute endpoint-count threshold (30), which
+# false-flagged every healthy build — Adobe's Partner API legitimately
+# exposes ~21 endpoints, not hundreds. This is the replacement heuristic.
+STALE_INDEX_FAILURE_FRACTION = 0.25
+
+
 @dataclass
 class IndexSnapshot:
     """A point-in-time snapshot of structured data extracted from the docs."""

--- a/src/vipmp_docs_mcp/prompts.py
+++ b/src/vipmp_docs_mcp/prompts.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 # Shared pieces for the training-curriculum walkthroughs. Centralising
 # these means every ``learn_*`` prompt makes the same promise (Adobe
@@ -50,8 +50,8 @@ def _tips_signpost(topic: str) -> str:
     )
 
 
-def register_prompts(mcp: FastMCP) -> None:
-    """Register all VIPMP prompts on the given FastMCP instance."""
+def register_prompts(mcp: MCPServer) -> None:
+    """Register all VIPMP prompts on the given MCPServer instance."""
 
     @mcp.prompt()
     def review_request_body(endpoint: str, body_json: str) -> str:

--- a/src/vipmp_docs_mcp/server.py
+++ b/src/vipmp_docs_mcp/server.py
@@ -1,5 +1,5 @@
 """
-FastMCP server — registers tools and runs the MCP transport.
+MCP server — registers tools and runs the MCP transport.
 
 Tool implementations live here but delegate real work to the supporting
 modules (fetcher, sitemap, html_cleaner). Disk cache, content search,
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 from typing import Literal
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 
+from . import __version__
 from .autositemap import build_sitemap, get_active_sitemap, save_sitemap
 from .cache import get_cache
 from .codegen import SUPPORTED_LANGUAGES, generate_snippet
@@ -25,6 +26,7 @@ from .extractors import (
 )
 from .fetcher import FetchError
 from .index import (
+    STALE_INDEX_FAILURE_FRACTION,
     USER_INDEX_PATH,
     build_index,
     get_active_index,
@@ -37,23 +39,6 @@ from .search import relevant_sections, search
 from .sitemap import normalize_path
 
 log = get_logger("server")
-
-
-# Fraction of the source sitemap that must fail to parse before
-# `vipmp_server_info` flags the active index as suspiciously
-# incomplete. The real regression in #4 surfaced as 57/72 pages
-# failing (~79% failure rate) because CI was building against the
-# stale hand-curated underscore paths that Adobe had migrated off.
-# A healthy build against Adobe's live sitemap parses every page
-# (0% failure). A small number of parse errors is normal when Adobe
-# publishes a new page the parser hasn't seen yet; 25% gives us
-# headroom for that without hiding real regressions.
-#
-# Prior versions used an absolute endpoint-count threshold (30),
-# which false-flagged every healthy build — Adobe's Partner API
-# legitimately exposes ~21 endpoints, not hundreds. This is the
-# replacement heuristic.
-STALE_INDEX_FAILURE_FRACTION = 0.25
 
 
 # Active sitemap: auto-generated (from Adobe's sitemap.xml, persisted to
@@ -81,8 +66,14 @@ def _known_paths() -> set[str]:
     return {normalize_path(e["path"]) for e in _active_sitemap}
 
 
-mcp = FastMCP(
+mcp = MCPServer(
     "vipmp-docs",
+    # Reported to clients in the initialize handshake. `__version__` is the
+    # installed distribution version, which `auto-version-bump.yml` keeps in
+    # lockstep with `manifest.json` — so what the server advertises matches
+    # the .mcpb bundle release it came from. FastMCP 1.x had no `version`
+    # parameter at all and always handshook an empty string.
+    version=__version__,
     instructions=(
         "Look up Adobe VIP Marketplace Partner API documentation and reason about "
         "it structurally.\n"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -27,7 +27,7 @@ def _manifest() -> dict:
 
 
 def _registered_tool_names() -> set[str]:
-    """Names of every tool the FastMCP server actually registers."""
+    """Names of every tool the MCP server actually registers."""
     from vipmp_docs_mcp.server import mcp
 
     return {tool.name for tool in asyncio.run(mcp.list_tools())}
@@ -70,3 +70,24 @@ class TestManifestVersion:
     def test_manifest_version_matches_pyproject(self):
         pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
         assert _manifest()["version"] == pyproject["project"]["version"]
+
+    def test_server_handshake_reports_the_installed_version(self):
+        """
+        The version the server advertises in the initialize handshake is the
+        one users quote in bug reports, so it must be wired to the package
+        metadata rather than left at the empty string FastMCP 1.x always
+        sent (nothing noticed for the whole 1.x era).
+
+        Asserted against installed metadata, not `pyproject.toml`: hatchling
+        derives one from the other at build time, and comparing to the file
+        would instead fail on a stale editable install — right after a
+        maintainer bumps the version, which is the worst moment for it.
+        """
+        from vipmp_docs_mcp import __version__
+        from vipmp_docs_mcp.server import mcp
+
+        assert mcp.version == __version__
+        assert mcp.version not in ("", "0.0.0"), (
+            "server is advertising no usable version — is `version=` still "
+            "passed to MCPServer, and is the package installed?"
+        )

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from vipmp_docs_mcp.prompts import register_prompts
 
@@ -23,17 +23,17 @@ RENDER_FAILED = "<render failed:"
 
 
 def _rendered_prompts() -> dict[str, str]:
-    """Register all prompts on a throwaway FastMCP instance and return
+    """Register all prompts on a throwaway MCPServer instance and return
     {prompt_name: rendered_body} for every walkthrough (no-arg prompts
     only — the parameterised ones are exercised by their callers).
 
     A prompt that raises while rendering is recorded with its traceback as
     the body rather than dropped, so the assertions below fail with the
     underlying error instead of a bare "didn't render"."""
-    mcp = FastMCP("test")
+    mcp = MCPServer("test")
     register_prompts(mcp)
 
-    # FastMCP exposes prompts via a private registry; we pull the
+    # MCPServer exposes prompts via a private registry; we pull the
     # callables out, call each no-arg prompt, and collect the string.
     # The no-arg prompts are the six walkthroughs; the router takes
     # optional args which we can pass defaults to.

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,0 +1,68 @@
+"""
+Tests that keep README.md honest about what the server exposes.
+
+The README's tool tables are what a human reads before installing, and
+nothing kept them in sync with `server.py`. Both directions had drifted:
+`vipmp_server_info` shipped and was never documented, and the tables still
+cited `get_vipmp_releases`, removed in 0.12.0 in favour of
+`list_vipmp_releases`. `tests/test_manifest.py` catches the equivalent drift
+in `manifest.json`; this catches it in the prose.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+README_PATH = REPO_ROOT / "README.md"
+
+# Backticked lowercase snake_case identifiers. Filtered below to those that
+# look like MCP entry points; matches with or without a trailing "(", since
+# the README cites tools both ways.
+BACKTICKED = re.compile(r"`([a-z][a-z0-9_]*)\(?")
+
+# Same shape as a tool name but not one: the package directory, which appears
+# inside backticked file paths.
+NOT_TOOLS = frozenset({"vipmp_docs_mcp"})
+
+
+def _registered(kind: str) -> set[str]:
+    from vipmp_docs_mcp.server import mcp
+
+    lister = mcp.list_tools if kind == "tools" else mcp.list_prompts
+    return {item.name for item in asyncio.run(lister())}
+
+
+def _tool_shaped_mentions() -> set[str]:
+    """
+    Backticked identifiers in the README that are shaped like a tool name:
+    snake_case and containing "vipmp". The underscore requirement drops the
+    bare `vipmp` that falls out of backticked `vipmp-docs-mcp`, since the
+    pattern stops at the hyphen.
+    """
+    tokens = set(BACKTICKED.findall(README_PATH.read_text(encoding="utf-8")))
+    return {t for t in tokens if "vipmp" in t and "_" in t} - NOT_TOOLS
+
+
+class TestReadmeToolParity:
+    """
+    The README must document exactly the tools the server registers — an
+    undocumented tool goes unused, and a documented-but-removed one sends
+    readers looking for something that will never answer.
+    """
+
+    def test_readme_documents_every_registered_tool(self):
+        missing = _registered("tools") - _tool_shaped_mentions()
+        assert not missing, (
+            f"tools registered in server.py but absent from README.md: {sorted(missing)}"
+        )
+
+    def test_readme_cites_no_unknown_tools(self):
+        # Prompts share the naming shape and are documented in their own
+        # table, so they are legitimate mentions rather than stale tools.
+        stale = _tool_shaped_mentions() - _registered("tools") - _registered("prompts")
+        assert not stale, (
+            f"tools cited in README.md but not registered in server.py: {sorted(stale)}"
+        )


### PR DESCRIPTION
## Why

The scheduled index refresh failed on 2026-07-29 ([run 30425230773](https://github.com/softwareone-platform/swo-adobe-vipm-docs-mcp/actions/runs/30425230773)):

```
File "src/vipmp_docs_mcp/server.py", line 13, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

`mcp` 2.0.0 published on 2026-07-28 13:45 UTC — between the previous green run (05:25) and this one (05:29) — and moved `mcp.server.fastmcp.FastMCP` to `mcp.server.mcpserver.MCPServer`. The pin was `mcp[cli]>=1.0.0` with no ceiling, so the run resolved 2.0.0.

Notably the rebuild itself **succeeded**. The failure was in the **Validate structural invariants** step, which imported `STALE_INDEX_FAILURE_FRACTION` from `server.py` and so pulled in the whole SDK to read one float.

## What changed

Three independent things had to be wrong for a docs-index refresh to break on an SDK release, so this fixes all three rather than just the pin.

**1. Target the 2.0 API.** The server surface is a rename — `.tool()`, `.prompt()` and `.run()` signatures are unchanged, and `ToolAnnotations` still accepts its camelCase aliases via pydantic — so no tool or prompt definition needed touching. All 20 tools and 13 prompts register and serve identically.

The one behavioural break was client-side: `InitializeResult.serverInfo` is now `server_info` (2.0 renamed model fields to snake_case; aliases cover construction but *not* attribute access). That fails at runtime, not import time — the smoke test found it, reading the diff would not have. Fixed in `scripts/smoke_test.py` and `examples/list_tools.py`.

**2. Add a `<3` ceiling.** `uv.lock` is gitignored, so the pin is the only thing standing between a major SDK release and every fresh resolve.

**3. Stop importing `server` from the workflow.** `STALE_INDEX_FAILURE_FRACTION` moved from `server.py` to `index.py`, next to the `parse_errors` and `source_sitemap_size` fields it is measured against. The validation step no longer needs the MCP SDK, so an SDK release can't break the index refresh this way again.

**Also: the server now reports its version.** `MCPServer(version=__version__)` — something 1.x couldn't do, as FastMCP had no `version` parameter. The handshake had advertised an empty string for the whole 1.x era, unnoticed; `examples/list_tools.py` printed a bare `v` on connect. It now reports `0.14.0`.

The accompanying test asserts against installed metadata rather than `pyproject.toml` on purpose: comparing to the file fails on a stale editable install, which is exactly the state a maintainer is in immediately after bumping the version. It caught that on itself during this change.

## Release

Bumped to **0.14.0** in `pyproject.toml` + `manifest.json`, `CHANGELOG.md` `[Unreleased]` moved under a dated heading with its comparison link. Minor rather than patch because the minimum supported `mcp` is now 2.0 — this changes what users resolve on install.

Per `CONTRIBUTING.md`'s manual release path, the tag is pushed after this merges.

## Verification

Full pre-tag check from `CONTRIBUTING.md`, against `mcp` 2.0.0 and `ruff` 0.16.0:

- `ruff check` + `ruff format --check` clean across `src/ tests/ scripts/ examples/`
- **216 tests passing** (215 + the new version assertion)
- **`scripts/smoke_test.py`: all 23 checks passing** over real stdio, handshake reporting `version=0.14.0`. CI does not run this — it needs network — and it is what caught the `server_info` break.
- All three `examples/` scripts run
- The failing workflow step extracted **verbatim** from `refresh-index.yml` and run locally:
  `OK: schema_version=5 (want 5), endpoints=22 (min 10), error_codes=70 (min 20), status_codes=12 (min 8), schemas=18 (min 5), parse_errors=0/86`

## Note

`mcp` 2.0 depends on `httpx2`, so our `httpx` dependency now resolves alongside it rather than being shared. No conflict, but the install footprint grew: `opentelemetry-api`, `truststore` and `mcp-types` added, `pydantic-settings` dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)